### PR TITLE
chore: prepare release 4.1.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,7 +2,7 @@
 name: cui-jsf-test-basic
 
 release:
-  current-version: 4.1.1
+  current-version: 4.1.2
   next-version: 4.0-SNAPSHOT
   create-github-release: true
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.3.4</version>
+        <version>1.4.0</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.test</groupId>
@@ -29,6 +29,7 @@
         <system>GitHub Issues</system>
     </issueManagement>
     <properties>
+        <maven.compiler.release>17</maven.compiler.release>
         <maven.jar.plugin.automatic.module.name>de.cuioss.test.jsf</maven.jar.plugin.automatic.module.name>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- Update `cui-java-parent` from 1.3.4 to 1.4.0
- Add explicit `maven.compiler.release=17` (applied by OpenRewrite)
- Increment release version to 4.1.2 in `.github/project.yml`

## Test plan
- [x] `./mvnw -Ppre-commit clean install` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)