### PR TITLE
chore: configure dependency propagation

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -15,3 +15,11 @@ pages:
 github-automation:
   auto-merge-build-versions: true
   auto-merge-build-timeout: 300
+
+consumers:
+  - cuioss-parent-pom:version.cui.test.jsf.basic
+
+dependency-propagation:
+  group-id: de.cuioss.test
+  artifact-id: cui-jsf-test-basic
+  scope: dependency


### PR DESCRIPTION
## Summary
- Add `consumers` and `dependency-propagation` config to `project.yml`
- On release, propagates version to `cuioss-parent-pom` (property `version.cui.test.jsf.basic`)

## Test plan
- [ ] CI build passes (config-only change to project.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)