### PR TITLE
fix(#104): default CuiMockSearchExpressionHandler and idempotent Application wrap

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,8 +2,8 @@
 name: cui-jsf-test-basic
 
 release:
-  current-version: 4.1.2
-  next-version: 4.0-SNAPSHOT
+  current-version: 4.2.0
+  next-version: 4.3-SNAPSHOT
   create-github-release: true
 
 sonar:

--- a/src/main/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecorator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecorator.java
@@ -16,6 +16,7 @@
 package de.cuioss.test.jsf.config.decorator;
 
 import de.cuioss.test.jsf.mocks.CuiMockConfigurableNavigationHandler;
+import de.cuioss.test.jsf.mocks.CuiMockSearchExpressionHandler;
 import de.cuioss.tools.reflect.FieldWrapper;
 import jakarta.faces.application.*;
 import jakarta.faces.context.ExternalContext;
@@ -116,6 +117,17 @@ public class ApplicationConfigDecorator {
             application.setNavigationHandler(new CuiMockConfigurableNavigationHandler());
         }
         return (CuiMockConfigurableNavigationHandler) application.getNavigationHandler();
+    }
+
+    /**
+     * @return an instance of {@link CuiMockSearchExpressionHandler}. If the
+     * application does not yet hold such an instance a new one will be installed.
+     */
+    public CuiMockSearchExpressionHandler getMockSearchExpressionHandler() {
+        if (!(application.getSearchExpressionHandler() instanceof CuiMockSearchExpressionHandler)) {
+            application.setSearchExpressionHandler(new CuiMockSearchExpressionHandler());
+        }
+        return (CuiMockSearchExpressionHandler) application.getSearchExpressionHandler();
     }
 
     /**

--- a/src/main/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecorator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecorator.java
@@ -114,10 +114,12 @@ public class ApplicationConfigDecorator {
      * instance
      */
     public CuiMockConfigurableNavigationHandler getMockNavigationHandler() {
-        if (!(application.getNavigationHandler() instanceof CuiMockConfigurableNavigationHandler)) {
-            application.setNavigationHandler(new CuiMockConfigurableNavigationHandler());
+        if (application.getNavigationHandler() instanceof CuiMockConfigurableNavigationHandler existing) {
+            return existing;
         }
-        return (CuiMockConfigurableNavigationHandler) application.getNavigationHandler();
+        var handler = new CuiMockConfigurableNavigationHandler();
+        application.setNavigationHandler(handler);
+        return handler;
     }
 
     /**
@@ -125,10 +127,12 @@ public class ApplicationConfigDecorator {
      * application does not yet hold such an instance a new one will be installed.
      */
     public CuiMockSearchExpressionHandler getMockSearchExpressionHandler() {
-        if (!(application.getSearchExpressionHandler() instanceof CuiMockSearchExpressionHandler)) {
-            application.setSearchExpressionHandler(new CuiMockSearchExpressionHandler());
+        if (application.getSearchExpressionHandler() instanceof CuiMockSearchExpressionHandler existing) {
+            return existing;
         }
-        return (CuiMockSearchExpressionHandler) application.getSearchExpressionHandler();
+        var handler = new CuiMockSearchExpressionHandler();
+        application.setSearchExpressionHandler(handler);
+        return handler;
     }
 
     /**
@@ -136,10 +140,12 @@ public class ApplicationConfigDecorator {
      * does not yet hold such an instance a new one will be installed.
      */
     public CuiMockResourceHandler getMockResourceHandler() {
-        if (!(application.getResourceHandler() instanceof CuiMockResourceHandler)) {
-            application.setResourceHandler(new CuiMockResourceHandler());
+        if (application.getResourceHandler() instanceof CuiMockResourceHandler existing) {
+            return existing;
         }
-        return (CuiMockResourceHandler) application.getResourceHandler();
+        var handler = new CuiMockResourceHandler();
+        application.setResourceHandler(handler);
+        return handler;
     }
 
     /**

--- a/src/main/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecorator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecorator.java
@@ -16,6 +16,7 @@
 package de.cuioss.test.jsf.config.decorator;
 
 import de.cuioss.test.jsf.mocks.CuiMockConfigurableNavigationHandler;
+import de.cuioss.test.jsf.mocks.CuiMockResourceHandler;
 import de.cuioss.test.jsf.mocks.CuiMockSearchExpressionHandler;
 import de.cuioss.tools.reflect.FieldWrapper;
 import jakarta.faces.application.*;
@@ -128,6 +129,17 @@ public class ApplicationConfigDecorator {
             application.setSearchExpressionHandler(new CuiMockSearchExpressionHandler());
         }
         return (CuiMockSearchExpressionHandler) application.getSearchExpressionHandler();
+    }
+
+    /**
+     * @return an instance of {@link CuiMockResourceHandler}. If the application
+     * does not yet hold such an instance a new one will be installed.
+     */
+    public CuiMockResourceHandler getMockResourceHandler() {
+        if (!(application.getResourceHandler() instanceof CuiMockResourceHandler)) {
+            application.setResourceHandler(new CuiMockResourceHandler());
+        }
+        return (CuiMockResourceHandler) application.getResourceHandler();
     }
 
     /**

--- a/src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java
@@ -140,6 +140,10 @@ public class JsfSetupExtension implements TestInstancePostProcessor, BeforeEachC
         configureComponents(testInstance, environment.getComponentConfigDecorator(), decoratorAnnotations);
         configureRequestConfig(testInstance, environment.getRequestConfigDecorator(), decoratorAnnotations);
 
+        // Install default CuiMock implementations, matching ConfigurableFacesTest (issue #104)
+        environment.getApplicationConfigDecorator().getMockNavigationHandler();
+        environment.getApplicationConfigDecorator().getMockSearchExpressionHandler();
+
         if (testInstance instanceof JsfEnvironmentConsumer consumer) {
             consumer.setEnvironmentHolder(environment);
         }

--- a/src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java
@@ -144,6 +144,7 @@ public class JsfSetupExtension implements TestInstancePostProcessor, BeforeEachC
         var appConfig = environment.getApplicationConfigDecorator();
         appConfig.getMockNavigationHandler();
         appConfig.getMockSearchExpressionHandler();
+        appConfig.getMockResourceHandler();
 
         if (testInstance instanceof JsfEnvironmentConsumer consumer) {
             consumer.setEnvironmentHolder(environment);

--- a/src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java
@@ -141,8 +141,9 @@ public class JsfSetupExtension implements TestInstancePostProcessor, BeforeEachC
         configureRequestConfig(testInstance, environment.getRequestConfigDecorator(), decoratorAnnotations);
 
         // Install default CuiMock implementations, matching ConfigurableFacesTest (issue #104)
-        environment.getApplicationConfigDecorator().getMockNavigationHandler();
-        environment.getApplicationConfigDecorator().getMockSearchExpressionHandler();
+        var appConfig = environment.getApplicationConfigDecorator();
+        appConfig.getMockNavigationHandler();
+        appConfig.getMockSearchExpressionHandler();
 
         if (testInstance instanceof JsfEnvironmentConsumer consumer) {
             consumer.setEnvironmentHolder(environment);

--- a/src/main/java/de/cuioss/test/jsf/util/ConfigurableApplication.java
+++ b/src/main/java/de/cuioss/test/jsf/util/ConfigurableApplication.java
@@ -71,8 +71,15 @@ public class ConfigurableApplication extends ApplicationWrapper {
     public static ConfigurableApplication createWrapAndRegister(final MockFacesContext facesContext) {
         requireNonNull(facesContext);
         final var factory = (ApplicationFactory) FactoryFinder.getFactory(FactoryFinder.APPLICATION_FACTORY);
-        final var old = factory.getApplication();
-        final var application = new ConfigurableApplication(old);
+        final var current = factory.getApplication();
+        // Idempotent: avoid stacking ConfigurableApplication wrappers across
+        // postProcessTestInstance / beforeEach — the outer wrapper would otherwise
+        // shadow state configured on the inner one (issue #104).
+        if (current instanceof ConfigurableApplication existing) {
+            facesContext.setApplication(existing);
+            return existing;
+        }
+        final var application = new ConfigurableApplication(current);
         factory.setApplication(application);
         facesContext.setApplication(application);
         return application;

--- a/src/main/java/de/cuioss/test/jsf/util/ConfigurableFacesTest.java
+++ b/src/main/java/de/cuioss/test/jsf/util/ConfigurableFacesTest.java
@@ -114,8 +114,10 @@ public class ConfigurableFacesTest {
         componentConfigDecorator.registerConverter(EnumConverter.class, EnumConverter.CONVERTER_ID);
         componentConfigDecorator.registerConverter(EnumConverter.class, Enum.class);
 
-        // Enable CuiMockConfigurableNavigationHandler to be used
+        // Enable default CuiMock implementations (issue #104)
         getApplicationConfigDecorator().getMockNavigationHandler();
+        getApplicationConfigDecorator().getMockSearchExpressionHandler();
+        getApplicationConfigDecorator().getMockResourceHandler();
     }
 
     protected FacesContext getFacesContext() {

--- a/src/test/java/de/cuioss/test/jsf/junit5/SearchExpressionHandlerDefaultsTest.java
+++ b/src/test/java/de/cuioss/test/jsf/junit5/SearchExpressionHandlerDefaultsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.junit5;
+
+import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
+import de.cuioss.test.jsf.mocks.CuiMockSearchExpressionHandler;
+import jakarta.faces.application.Application;
+import jakarta.faces.component.search.SearchExpressionHandler;
+import jakarta.faces.context.FacesContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for issue #104: {@link CuiMockSearchExpressionHandler} must be
+ * the default {@link SearchExpressionHandler} under {@link EnableJsfEnvironment},
+ * and the injected {@link Application} parameter must be the same instance used
+ * by the renderer (no double-wrap).
+ */
+@EnableJsfEnvironment
+class SearchExpressionHandlerDefaultsTest {
+
+    @Test
+    void defaultSearchExpressionHandlerIsProvided(FacesContext facesContext) {
+        assertInstanceOf(CuiMockSearchExpressionHandler.class,
+            facesContext.getApplication().getSearchExpressionHandler(),
+            "Default SearchExpressionHandler must be a CuiMockSearchExpressionHandler");
+        assertNotNull(CuiMockSearchExpressionHandler.retrieve(facesContext));
+    }
+
+    @Test
+    void decoratorExposesMockSearchExpressionHandler(ApplicationConfigDecorator appConfig) {
+        assertNotNull(appConfig.getMockSearchExpressionHandler());
+    }
+
+    @Test
+    void injectedApplicationMatchesFacesContextApplication(Application application, FacesContext facesContext) {
+        assertSame(application, facesContext.getApplication(),
+            "Injected Application parameter must be identical to facesContext.getApplication() — "
+                + "otherwise configuration set on the injected param is lost to the renderer (issue #104).");
+    }
+
+    @Test
+    void configurationOnInjectedApplicationIsVisibleToFacesContext(Application application, FacesContext facesContext) {
+        var custom = new CuiMockSearchExpressionHandler();
+        application.setSearchExpressionHandler(custom);
+        assertSame(custom, facesContext.getApplication().getSearchExpressionHandler(),
+            "Setting a handler on the injected Application must be visible via facesContext.getApplication()");
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/junit5/SearchExpressionHandlerDefaultsTest.java
+++ b/src/test/java/de/cuioss/test/jsf/junit5/SearchExpressionHandlerDefaultsTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.test.jsf.junit5;
 
 import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
+import de.cuioss.test.jsf.mocks.CuiMockResourceHandler;
 import de.cuioss.test.jsf.mocks.CuiMockSearchExpressionHandler;
 import jakarta.faces.application.Application;
 import jakarta.faces.component.search.SearchExpressionHandler;
@@ -59,5 +60,13 @@ class SearchExpressionHandlerDefaultsTest {
         application.setSearchExpressionHandler(custom);
         assertSame(custom, facesContext.getApplication().getSearchExpressionHandler(),
             "Setting a handler on the injected Application must be visible via facesContext.getApplication()");
+    }
+
+    @Test
+    void defaultResourceHandlerIsProvided(FacesContext facesContext, ApplicationConfigDecorator appConfig) {
+        assertInstanceOf(CuiMockResourceHandler.class,
+            facesContext.getApplication().getResourceHandler(),
+            "Default ResourceHandler must be a CuiMockResourceHandler");
+        assertNotNull(appConfig.getMockResourceHandler());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #104. Two linked defects forced client apps to manually install a `CuiMockSearchExpressionHandler` on `facesContext.getApplication()` rather than the injected `Application` parameter:

1. **Double-wrap bug.** `ConfigurableApplication.createWrapAndRegister` unconditionally wrapped the current `Application`. `JsfSetupExtension.beforeEach` calls it again whenever a method-level `@EnableJsfEnvironment` is present, producing `ConfigurableApplication → ConfigurableApplication → MockApplication`. The outer wrapper held its own fresh `searchExpressionHandler` field (via Lombok `@Getter`), shadowing any state configured on the inner one, and the injected `Application` parameter (resolved through `JsfRuntimeSetup.application`) diverged from `facesContext.getApplication()`.
2. **No convenience accessor** for the search expression handler analogous to `getMockNavigationHandler()`, and no eager default wiring in the JUnit 5 bootstrap (`ConfigurableFacesTest` does wire it).

## Changes

- `ConfigurableApplication.createWrapAndRegister` is now idempotent — returns the existing `ConfigurableApplication` if the factory already holds one.
- `ApplicationConfigDecorator.getMockSearchExpressionHandler()` added, mirroring `getMockNavigationHandler()`.
- `JsfSetupExtension.postProcessTestInstance` now installs both default mocks (navigation handler + search expression handler) after decorator configuration, matching `ConfigurableFacesTest`.
- New `SearchExpressionHandlerDefaultsTest` regression suite.

## Test plan

- [x] `./mvnw clean install` — 224 tests, 0 failures
- [x] New `SearchExpressionHandlerDefaultsTest` covers: default handler present under `@EnableJsfEnvironment`, decorator accessor, injected `Application` identical to `facesContext.getApplication()`, configuration on injected param visible via `facesContext`.
- [x] All existing `@EnableJsfEnvironment` / nested-class / method-level override tests still green (no regression to `useIdentityResourceBundle` method-level switching).