### PR TITLE
chore: initialize plan-marshall configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@
 *.project
 .DS_Store
 .asciidoctorconfig.adoc
+
+# Planning system (managed by /marshall-steward)
+# Runtime state (plans, run-configuration, lessons-learned, memory, logs — managed by plan-marshall)
+.plan/*
+!.plan/marshal.json
+!.plan/project-architecture/
+!.plan/plugin-doctor.yml
+.plan/local/worktrees/

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -1,0 +1,182 @@
+{
+  "plan": {
+    "effort": "level-3",
+    "open_in_ide": true,
+    "coverage": {
+      "thoroughness": "inherit",
+      "scope": "inherit"
+    },
+    "phase-1-init": {
+      "branch_strategy": "feature",
+      "use_worktree": true,
+      "effort": "level-3",
+      "init_without_asking": true,
+      "deep_lane": "auto",
+      "escalation": "auto"
+    },
+    "phase-2-refine": {
+      "confidence_threshold": 95,
+      "compatibility": "breaking",
+      "simplicity": "lean",
+      "effort": "level-3",
+      "revalidation": "auto"
+    },
+    "phase-3-outline": {
+      "plan_without_asking": false,
+      "qgate": "auto",
+      "effort": "level-4"
+    },
+    "phase-4-plan": {
+      "execute_without_asking": true,
+      "effort": "level-3"
+    },
+    "phase-5-execute": {
+      "commit_and_push": true,
+      "max_iterations": 5,
+      "per_deliverable_build": "compile+scoped-test",
+      "per_task_budget_reserve_tokens": "50K",
+      "steps": [
+        "default:quality_check",
+        "default:build_verify",
+        "default:coverage_check"
+      ],
+      "effort": {
+        "default": "level-4",
+        "verification-feedback": "level-3"
+      }
+    },
+    "phase-6-finalize": {
+      "max_iterations": 3,
+      "review_bot_buffer_seconds": 180,
+      "pr_merge_strategy": "squash",
+      "finalize_without_asking": true,
+      "loop_back_without_asking": false,
+      "auto_merge_after_ci": true,
+      "self_review": "auto",
+      "qgate": "auto",
+      "plugin_doctor": "auto",
+      "simplify": "auto",
+      "checks_wait_timeout_seconds": 600,
+      "auto_rebase_threshold": "no_overlap_only",
+      "drop_review_on_scope_gate": false,
+      "steps": [
+        "default:pre-push-quality-gate",
+        "default:finalize-step-simplify",
+        "default:finalize-step-whole-tree-gate",
+        "default:commit-push",
+        "default:create-pr",
+        "default:ci-verify",
+        "default:automated-review",
+        "default:sonar-roundtrip",
+        "default:lessons-capture",
+        "default:branch-cleanup",
+        "default:record-metrics",
+        "default:finalize-step-print-phase-breakdown",
+        "default:archive-plan"
+      ],
+      "effort": {
+        "default": "level-3",
+        "verification-feedback": "level-3",
+        "post-run-review": "level-4"
+      }
+    }
+  },
+  "build": {
+    "queue": {
+      "max_slots": 5,
+      "max_retries": 10,
+      "upper_limit_seconds": 600
+    },
+    "map": {
+      "java": [
+        {
+          "glob": "pom.xml",
+          "role": "config",
+          "build_class": "verify"
+        },
+        {
+          "glob": "src/main/*.java",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "src/test/*.java",
+          "role": "test",
+          "build_class": "module-tests"
+        }
+      ]
+    }
+  },
+  "project": {
+    "default_base_branch": "main",
+    "working_prefixes": [
+      "feature/",
+      "fix/",
+      "chore/"
+    ]
+  },
+  "providers": [
+    {
+      "skill_name": "plan-marshall:workflow-integration-sonar",
+      "category": "other",
+      "description": "SonarCloud/SonarQube code analysis platform",
+      "url": "https://sonarcloud.io"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-github",
+      "category": "ci",
+      "verify_command": "gh auth status",
+      "description": "GitHub CI provider via gh CLI — PRs, issues, CI status, reviews",
+      "url": "https://api.github.com"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-git",
+      "category": "version-control",
+      "verify_command": "git config user.name",
+      "description": "Git version control via git CLI — commit, push, branch operations",
+      "url": "https://github.com/cuioss/cui-jsf-test-basic.git"
+    }
+  ],
+  "skill_domains": {
+    "system": {
+      "defaults": [],
+      "optionals": [],
+      "execute_task_skills": {
+        "documentation": "plan-marshall:execute-task",
+        "implementation": "plan-marshall:execute-task",
+        "module_testing": "plan-marshall:execute-task"
+      }
+    },
+    "general-dev": {
+      "bundle": "plan-marshall"
+    },
+    "documentation": {
+      "bundle": "pm-documents",
+      "workflow_skill_extensions": {
+        "triage": "pm-documents:ext-triage-docs"
+      }
+    },
+    "java": {
+      "bundle": "pm-dev-java",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-java:ext-triage-java"
+      }
+    },
+    "java-cui": {
+      "bundle": "pm-dev-java-cui"
+    },
+    "active_profiles": [
+      "implementation",
+      "module_testing",
+      "quality"
+    ]
+  },
+  "system": {
+    "retention": {
+      "logs_days": 1,
+      "archived_plans_days": 5,
+      "lessons_superseded_days": 0,
+      "temp_on_maintenance": true
+    }
+  }
+}

--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -1,0 +1,13 @@
+{
+  "description": "JSF testing framework extending MyFaces-Test with mock-based infrastructure for testing JSF components, validators, converters, and renderers in Jakarta EE 10 (JSF 4.1+); provides base test classes, HTML tree generation/assertion tools, and JUnit 5 integration.",
+  "description_reasoning": "Derived from CLAUDE.md Project Overview",
+  "extensions_used": [
+    "plan-marshall",
+    "pm-documents"
+  ],
+  "modules": {
+    "cui-jsf-test-basic": {},
+    "documentation": {}
+  },
+  "name": "cui-jsf-test-basic"
+}

--- a/.plan/project-architecture/cui-jsf-test-basic/enriched.json
+++ b/.plan/project-architecture/cui-jsf-test-basic/enriched.json
@@ -1,0 +1,79 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "library",
+  "purpose_reasoning": "Derived from CLAUDE.md Project Architecture",
+  "responsibility": "Core testing framework: JUnit 5 integration (@EnableJsfEnvironment), abstract base test classes for components/validators/converters/renderers, configuration decorators, and extended JSF mocks beyond MyFaces-Test.",
+  "responsibility_reasoning": "Derived from CLAUDE.md Project Architecture",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -1,0 +1,15 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "documentation",
+  "purpose_reasoning": "doc/ directory containing usage.adoc and migration.adoc",
+  "responsibility": "AsciiDoc documentation sources: usage guide and migration guide for the testing framework.",
+  "responsibility_reasoning": "doc/ directory containing usage.adoc and migration.adoc",
+  "skills_by_profile": {},
+  "skills_by_profile_reasoning": "",
+  "tips": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,3 +308,12 @@ See `doc/migration.adoc` for detailed migration guide.
 - JSF 4+ support: main branch (4.x releases)
 - JSF 2.3 support: Release 2.0.2 on v2 branch
 - Parent POM: `de.cuioss:cui-java-parent:0.9.9.6`
+
+## Temporary Files
+
+Use `.plan/temp/` for ALL temporary and generated files (covered by `Write(.plan/**)` permission — avoids permission prompts).
+
+## Tool Usage
+
+- Use proper tools (Edit, Read, Write) instead of shell commands (echo, cat)
+- Never use Bash for file operations (find, grep, cat, ls) — use Glob, Read, Grep tools instead


### PR DESCRIPTION
## Summary

Initializes the plan-marshall planning system for this repository (first-run `/marshall-steward` wizard).

### Changes
- **`.gitignore`** — managed planning-system block: ignores `.plan/*` while tracking `.plan/marshal.json` and `.plan/project-architecture/`.
- **`.plan/marshal.json`** — project configuration:
  - Providers: git, github (CI, auto-detected), sonar
  - Skill domains: general-dev, documentation, java, java-cui
  - Build map: java (pom.xml→verify, src/main→compile, src/test→module-tests)
  - Default finalize pipeline (incl. sonar-roundtrip)
- **`.plan/project-architecture/`** — discovered-module metadata for the two modules (library + documentation).
- **`CLAUDE.md`** — appended temp-files and tool-usage guidance.

### Notes
- The per-machine executor (`.plan/execute-script.py`) is intentionally **not** committed (contains local absolute paths; regenerated per-machine).
- Sonar credentials were deferred; `sonar-roundtrip` is wired but inactive until credentials are configured.