### PR TITLE
fix(#74): Introduce JsfTestSetup as non-deprecated replacement for @JsfTestConfiguration bound

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -16,7 +16,7 @@
     },
     "phase-2-refine": {
       "confidence_threshold": 95,
-      "compatibility": "breaking",
+      "compatibility": "deprecation",
       "simplicity": "lean",
       "effort": "level-3",
       "revalidation": "auto"
@@ -61,9 +61,9 @@
       "drop_review_on_scope_gate": false,
       "steps": [
         "default:pre-push-quality-gate",
-        "default:finalize-step-simplify",
         "default:finalize-step-whole-tree-gate",
         "default:commit-push",
+        "default:finalize-step-simplify",
         "default:create-pr",
         "default:ci-verify",
         "default:automated-review",

--- a/README.adoc
+++ b/README.adoc
@@ -52,3 +52,5 @@ Extension for http://myfaces.apache.org/test/index.html[MyFaces-Test] that uses 
 link:doc/usage.adoc[Usage Documentation]
 
 link:doc/migration/4.1.adoc[Migration Guide to 4.1]
+
+link:doc/migration/4.3.adoc[Migration Guide to 4.3]

--- a/doc/migration/4.3.adoc
+++ b/doc/migration/4.3.adoc
@@ -1,0 +1,83 @@
+= JSF Testing Framework Migration Guide to 4.3
+
+== Introduction
+
+This document describes the migration to *4.3* for reusable `@JsfTestConfiguration` configuration classes.
+
+In *4.3* the JSF testing framework introduces `JsfTestSetup`, a new non-deprecated interface that replaces the deprecated `JsfTestContextConfigurator` hierarchy as the configuration target for `@JsfTestConfiguration`. This change removes the need to suppress deprecation warnings purely to reference the configurator types in the annotation.
+
+No dependency-version change is required to adopt the new target: the release is already `4.3-SNAPSHOT`, and the next release is `4.3.0`.
+
+== Overview of Changes
+
+The annotation bound of `@JsfTestConfiguration` has changed:
+
+* `@JsfTestConfiguration.value()` now accepts `Class<? extends JsfTestSetup>[]` (previously `Class<? extends JsfTestContextConfigurator>[]`).
+* `JsfTestSetup` is the new, non-deprecated configuration target.
+
+Key changes include:
+
+* Introduction of the non-deprecated `de.cuioss.test.jsf.config.JsfTestSetup` interface.
+* Re-parenting of the legacy configurator sub-interfaces (`ApplicationConfigurator`, `ComponentConfigurator`, `RequestConfigurator`) onto `JsfTestSetup`.
+* Retargeting of `@JsfTestConfiguration.value()` to `Class<? extends JsfTestSetup>[]`.
+* Broadening of the configuration dispatch so a bare `JsfTestSetup` implementor has all three configure methods invoked.
+* Maintenance of backward compatibility so existing configuration classes continue to work unchanged.
+
+== The Three Default Methods
+
+`JsfTestSetup` declares three `default` no-op methods, so an implementor overrides only the aspects it needs and is no longer required to chain through a deprecated sub-interface:
+
+* `configureApplication(ApplicationConfigDecorator)` — navigation cases, resource bundles, and other application-level settings.
+* `configureComponents(ComponentConfigDecorator)` — registration of components, renderers, converters, and validators.
+* `configureRequest(RequestConfigDecorator)` — request- and response-level configuration.
+
+Because every method has an empty default implementation, a configuration class is free to implement just one, two, or all three callbacks.
+
+== Migration Guide
+
+To migrate a reusable configuration class from a deprecated configurator sub-interface to `JsfTestSetup`:
+
+1. Change the `implements` clause from the legacy sub-interface to `JsfTestSetup`.
+2. Keep the existing `configure*` method bodies and their `@Override` annotations — they now override the `JsfTestSetup` defaults.
+3. Remove the legacy sub-interface import and the `@SuppressWarnings("java:S1874")` annotation that was added purely to reference the deprecated type.
+
+=== Before Migration
+
+[source,java]
+----
+@SuppressWarnings("java:S1874")
+public class MyApplicationConfiguration implements ApplicationConfigurator {
+
+    @Override
+    public void configureApplication(ApplicationConfigDecorator decorator) {
+        decorator.registerNavigationCase("outcome", "targetViewId");
+    }
+}
+----
+
+=== After Migration
+
+[source,java]
+----
+public class MyApplicationConfiguration implements JsfTestSetup {
+
+    @Override
+    public void configureApplication(ApplicationConfigDecorator decorator) {
+        decorator.registerNavigationCase("outcome", "targetViewId");
+    }
+}
+----
+
+The `@SuppressWarnings("java:S1874")` annotation is no longer needed because `JsfTestSetup` is not deprecated. The `configureComponents` and `configureRequest` callbacks are inherited as no-op defaults and need not be implemented.
+
+== Backward Compatibility
+
+The change is a backward-compatible API extension:
+
+* The legacy sub-interfaces (`ApplicationConfigurator`, `ComponentConfigurator`, `RequestConfigurator`) are re-parented onto `JsfTestSetup` and retained as `@Deprecated`.
+* Because they are now sub-types of `JsfTestSetup`, existing `@JsfTestConfiguration(SomeConfigurator.class)` usages continue to satisfy the new `Class<? extends JsfTestSetup>[]` bound and compile unchanged.
+* Migration to `JsfTestSetup` is recommended but not required; existing code continues to work without modification.
+
+== Conclusion
+
+Adopting `JsfTestSetup` removes the deprecation-warning suppression that the legacy configurator hierarchy forced on every `@JsfTestConfiguration` consumer, while leaving all existing configuration classes working unchanged. Migration is a small, mechanical change that can be done incrementally.

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <system>GitHub Issues</system>
     </issueManagement>
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <maven.jar.plugin.automatic.module.name>de.cuioss.test.jsf</maven.jar.plugin.automatic.module.name>
     </properties>
     <dependencyManagement>

--- a/src/main/java/de/cuioss/test/jsf/component/ComponentTestHelper.java
+++ b/src/main/java/de/cuioss/test/jsf/component/ComponentTestHelper.java
@@ -75,8 +75,8 @@ public final class ComponentTestHelper {
             map.put(configuredName, resolvePropertyForConfiguredName(instance, configuredName));
         }
 
-        var filtered = AnnotationHelper.modifyPropertyMetadata(map, defaultValued, Collections.emptyList(),
-            Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), unorderedCollection);
+        var filtered = AnnotationHelper.modifyPropertyMetadata(map, defaultValued, List.of(),
+            List.of(), List.of(), List.of(), unorderedCollection);
 
         List<ComponentPropertyMetadata> found = new ArrayList<>();
         for (Entry<String, PropertyMetadata> entry : filtered.entrySet()) {

--- a/src/main/java/de/cuioss/test/jsf/config/ApplicationConfigurator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/ApplicationConfigurator.java
@@ -39,7 +39,7 @@ import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
  * See the migration guide for more details.
  */
 @Deprecated
-public interface ApplicationConfigurator extends JsfTestContextConfigurator {
+public interface ApplicationConfigurator extends JsfTestSetup {
 
     /**
      * Callback method for interacting with the {@link ApplicationConfigDecorator}
@@ -47,5 +47,6 @@ public interface ApplicationConfigurator extends JsfTestContextConfigurator {
      *
      * @param decorator is never null
      */
+    @Override
     void configureApplication(ApplicationConfigDecorator decorator);
 }

--- a/src/main/java/de/cuioss/test/jsf/config/ComponentConfigurator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/ComponentConfigurator.java
@@ -39,7 +39,7 @@ import de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator;
  * See the migration guide for more details.
  */
 @Deprecated
-public interface ComponentConfigurator extends JsfTestContextConfigurator {
+public interface ComponentConfigurator extends JsfTestSetup {
 
     /**
      * Callback method for interacting with the {@link ComponentConfigDecorator} at
@@ -47,5 +47,6 @@ public interface ComponentConfigurator extends JsfTestContextConfigurator {
      *
      * @param decorator is never null
      */
+    @Override
     void configureComponents(ComponentConfigDecorator decorator);
 }

--- a/src/main/java/de/cuioss/test/jsf/config/JsfTestConfiguration.java
+++ b/src/main/java/de/cuioss/test/jsf/config/JsfTestConfiguration.java
@@ -52,8 +52,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface JsfTestConfiguration {
 
     /**
-     * @return one or more concrete instances of {@link JsfTestContextConfigurator}
+     * @return one or more concrete instances of {@link JsfTestSetup}
      */
-    Class<? extends JsfTestContextConfigurator>[] value();
+    Class<? extends JsfTestSetup>[] value();
 
 }

--- a/src/main/java/de/cuioss/test/jsf/config/JsfTestConfiguration.java
+++ b/src/main/java/de/cuioss/test/jsf/config/JsfTestConfiguration.java
@@ -25,12 +25,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * This annotation can be used to configure certain aspects of the
- * configuration of the jsf-runtime for unit-testing. For simple cases the
- * test-class can implement the corresponding interfaces itself:
- * {@link ApplicationConfigurator}, {@link ComponentConfigurator},
- * {@link RequestConfigurator}. The base-class will
- * ensure that the corresponding methods will be called at setup-time. This is
- * useful for cases, where there is no need to reuse a certain configuration.
+ * configuration of the jsf-runtime for unit-testing. Configuration classes
+ * should implement {@link JsfTestSetup} and override only the methods they
+ * need. This is useful for cases where a certain configuration is reused
+ * across multiple test classes.
  * 
  * <p>
  * This annotation can be applied at both the type level (class) and method level.

--- a/src/main/java/de/cuioss/test/jsf/config/JsfTestSetup.java
+++ b/src/main/java/de/cuioss/test/jsf/config/JsfTestSetup.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.config;
+
+import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
+import de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator;
+import de.cuioss.test.jsf.config.decorator.RequestConfigDecorator;
+
+/**
+ * Unified configuration entry-point for JSF tests, intended to be referenced by
+ * {@link JsfTestConfiguration}. It is the non-deprecated replacement for the
+ * {@link JsfTestContextConfigurator} hierarchy (the {@code ApplicationConfigurator},
+ * {@code ComponentConfigurator} and {@code RequestConfigurator} sub-interfaces).
+ * <p>
+ * Implementations override only the configuration aspects they care about; every
+ * method has an empty default implementation, so a configuration class is free to
+ * implement just one, two, or all three callbacks.
+ * <p>
+ * Each callback receives the corresponding decorator and may use its fluent API to
+ * set up the JSF test environment:
+ * <ul>
+ *   <li>{@link #configureApplication(ApplicationConfigDecorator)} — navigation cases,
+ *       resource bundles, and other application-level settings.</li>
+ *   <li>{@link #configureComponents(ComponentConfigDecorator)} — registration of
+ *       components, renderers, converters, and validators.</li>
+ *   <li>{@link #configureRequest(RequestConfigDecorator)} — request and response
+ *       level configuration.</li>
+ * </ul>
+ *
+ * @author Oliver Wolff
+ */
+public interface JsfTestSetup {
+
+    /**
+     * Configures application-level aspects of the JSF test environment, such as
+     * navigation cases and resource bundles. The default implementation does nothing.
+     *
+     * @param applicationConfig the decorator providing the application configuration API,
+     *                          never {@code null}
+     */
+    default void configureApplication(ApplicationConfigDecorator applicationConfig) {
+        // no-op by default; implementations override as needed
+    }
+
+    /**
+     * Registers components, renderers, converters, and validators with the JSF test
+     * environment. The default implementation does nothing.
+     *
+     * @param componentConfig the decorator providing the component configuration API,
+     *                        never {@code null}
+     */
+    default void configureComponents(ComponentConfigDecorator componentConfig) {
+        // no-op by default; implementations override as needed
+    }
+
+    /**
+     * Configures request- and response-level aspects of the JSF test environment.
+     * The default implementation does nothing.
+     *
+     * @param requestConfig the decorator providing the request configuration API,
+     *                      never {@code null}
+     */
+    default void configureRequest(RequestConfigDecorator requestConfig) {
+        // no-op by default; implementations override as needed
+    }
+}

--- a/src/main/java/de/cuioss/test/jsf/config/RequestConfigurator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/RequestConfigurator.java
@@ -39,7 +39,7 @@ import de.cuioss.test.jsf.config.decorator.RequestConfigDecorator;
  * See the migration guide for more details.
  */
 @Deprecated
-public interface RequestConfigurator extends JsfTestContextConfigurator {
+public interface RequestConfigurator extends JsfTestSetup {
 
     /**
      * Callback method for interacting with the {@link RequestConfigDecorator} at
@@ -47,5 +47,6 @@ public interface RequestConfigurator extends JsfTestContextConfigurator {
      *
      * @param decorator is never null
      */
+    @Override
     void configureRequest(RequestConfigDecorator decorator);
 }

--- a/src/main/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecorator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecorator.java
@@ -28,7 +28,6 @@ import org.apache.myfaces.test.mock.MockHttpServletRequest;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -145,7 +144,7 @@ public class RequestConfigDecorator {
      */
     public RequestConfigDecorator setRequestLocale(final Locale... requestLocale) {
         var request = (CuiMockHttpServletRequest) externalContext.getRequest();
-        List<Locale> localeList = requestLocale == null ? Collections.emptyList() : Arrays.asList(requestLocale);
+        List<Locale> localeList = requestLocale == null ? List.of() : Arrays.asList(requestLocale);
         Locale locale = null;
         if (!localeList.isEmpty()) {
             locale = localeList.getFirst();

--- a/src/main/java/de/cuioss/test/jsf/defaults/BasicApplicationConfiguration.java
+++ b/src/main/java/de/cuioss/test/jsf/defaults/BasicApplicationConfiguration.java
@@ -15,8 +15,7 @@
  */
 package de.cuioss.test.jsf.defaults;
 
-import de.cuioss.test.jsf.config.ApplicationConfigurator;
-import de.cuioss.test.jsf.config.RequestConfigurator;
+import de.cuioss.test.jsf.config.JsfTestSetup;
 import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
 import de.cuioss.test.jsf.config.decorator.RequestConfigDecorator;
 
@@ -36,7 +35,7 @@ import static de.cuioss.tools.collect.CollectionLiterals.immutableSet;
  *
  * @author Oliver Wolff
  */
-public class BasicApplicationConfiguration implements ApplicationConfigurator, RequestConfigurator {
+public class BasicApplicationConfiguration implements JsfTestSetup {
 
     /**
      * Firefox user-agent

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequest.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequest.java
@@ -74,7 +74,7 @@ public class CuiMockHttpServletRequest extends MockHttpServletRequest {
 
     @Override
     public Collection<Part> getParts() {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override

--- a/src/main/java/de/cuioss/test/jsf/util/ConfigurationHelper.java
+++ b/src/main/java/de/cuioss/test/jsf/util/ConfigurationHelper.java
@@ -83,6 +83,8 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureComponents(registry));
+        getBareJsfTestSetups(configurations, ComponentConfigurator.class)
+            .forEach(instance -> instance.configureComponents(registry));
     }
 
     /**
@@ -108,6 +110,8 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureApplication(registry));
+        getBareJsfTestSetups(configurations, ApplicationConfigurator.class)
+            .forEach(instance -> instance.configureApplication(registry));
     }
 
     /**
@@ -133,22 +137,50 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureRequest(registry));
+        getBareJsfTestSetups(configurations, RequestConfigurator.class)
+            .forEach(instance -> instance.configureRequest(registry));
     }
 
     /**
      * @param configurations all configurators
      * @param configurator   class to check if assignable
      * @param <T>            target type
-     * @return list of {@link JsfTestContextConfigurator} with target type
+     * @return list of {@link JsfTestSetup} with target type
      */
     @SuppressWarnings("unchecked")
-    private static <T extends JsfTestContextConfigurator> List<T> getAssignableContextConfigurators(
+    private static <T extends JsfTestSetup> List<T> getAssignableContextConfigurators(
         final Collection<JsfTestConfiguration> configurations, final Class<T> configurator) {
         final List<T> instances = new ArrayList<>();
         for (final JsfTestConfiguration config : configurations) {
-            for (final Class<? extends JsfTestContextConfigurator> type : config.value()) {
+            for (final Class<? extends JsfTestSetup> type : config.value()) {
                 if (configurator.isAssignableFrom(type)) {
                     instances.add((T) new DefaultInstantiator<>(type).newInstance());
+                }
+            }
+        }
+        return instances;
+    }
+
+    /**
+     * Collects instances of bare {@link JsfTestSetup} implementors — types referenced by
+     * {@link JsfTestConfiguration#value()} that do <em>not</em> implement the given legacy
+     * sub-interface. These implementors are dispatched via the {@link JsfTestSetup} default
+     * methods, while legacy implementors are handled by the per-sub-interface dispatch path
+     * to avoid double-invocation.
+     *
+     * @param configurations the previously extracted annotations, must not be null
+     * @param legacyConfigurator the legacy sub-interface whose implementors are already
+     *                           dispatched elsewhere and must be excluded here
+     * @return list of {@link JsfTestSetup} instances that are not instances of the legacy
+     *         sub-interface
+     */
+    private static List<JsfTestSetup> getBareJsfTestSetups(final Collection<JsfTestConfiguration> configurations,
+        final Class<? extends JsfTestSetup> legacyConfigurator) {
+        final List<JsfTestSetup> instances = new ArrayList<>();
+        for (final JsfTestConfiguration config : configurations) {
+            for (final Class<? extends JsfTestSetup> type : config.value()) {
+                if (!legacyConfigurator.isAssignableFrom(type)) {
+                    instances.add(new DefaultInstantiator<>(type).newInstance());
                 }
             }
         }

--- a/src/main/java/de/cuioss/test/jsf/util/ConfigurationHelper.java
+++ b/src/main/java/de/cuioss/test/jsf/util/ConfigurationHelper.java
@@ -83,7 +83,7 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureComponents(registry));
-        getBareJsfTestSetups(configurations, ComponentConfigurator.class)
+        getBareJsfTestSetups(configurations)
             .forEach(instance -> instance.configureComponents(registry));
     }
 
@@ -110,7 +110,7 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureApplication(registry));
-        getBareJsfTestSetups(configurations, ApplicationConfigurator.class)
+        getBareJsfTestSetups(configurations)
             .forEach(instance -> instance.configureApplication(registry));
     }
 
@@ -137,7 +137,7 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureRequest(registry));
-        getBareJsfTestSetups(configurations, RequestConfigurator.class)
+        getBareJsfTestSetups(configurations)
             .forEach(instance -> instance.configureRequest(registry));
     }
 
@@ -163,23 +163,24 @@ public final class ConfigurationHelper {
 
     /**
      * Collects instances of bare {@link JsfTestSetup} implementors — types referenced by
-     * {@link JsfTestConfiguration#value()} that do <em>not</em> implement the given legacy
-     * sub-interface. These implementors are dispatched via the {@link JsfTestSetup} default
-     * methods, while legacy implementors are handled by the per-sub-interface dispatch path
-     * to avoid double-invocation.
+     * {@link JsfTestConfiguration#value()} that do <em>not</em> implement any of the legacy
+     * sub-interfaces ({@link ApplicationConfigurator}, {@link ComponentConfigurator},
+     * {@link RequestConfigurator}). These implementors are dispatched via the
+     * {@link JsfTestSetup} default methods for all configuration phases, while legacy
+     * implementors are handled by the per-sub-interface dispatch path to avoid
+     * redundant instantiations.
      *
      * @param configurations the previously extracted annotations, must not be null
-     * @param legacyConfigurator the legacy sub-interface whose implementors are already
-     *                           dispatched elsewhere and must be excluded here
-     * @return list of {@link JsfTestSetup} instances that are not instances of the legacy
-     *         sub-interface
+     * @return list of {@link JsfTestSetup} instances that do not implement any legacy
+     *         configurator sub-interface
      */
-    private static List<JsfTestSetup> getBareJsfTestSetups(final Collection<JsfTestConfiguration> configurations,
-        final Class<? extends JsfTestSetup> legacyConfigurator) {
+    private static List<JsfTestSetup> getBareJsfTestSetups(final Collection<JsfTestConfiguration> configurations) {
         final List<JsfTestSetup> instances = new ArrayList<>();
         for (final JsfTestConfiguration config : configurations) {
             for (final Class<? extends JsfTestSetup> type : config.value()) {
-                if (!legacyConfigurator.isAssignableFrom(type)) {
+                if (!ApplicationConfigurator.class.isAssignableFrom(type)
+                    && !ComponentConfigurator.class.isAssignableFrom(type)
+                    && !RequestConfigurator.class.isAssignableFrom(type)) {
                     instances.add(new DefaultInstantiator<>(type).newInstance());
                 }
             }

--- a/src/test/java/de/cuioss/test/jsf/junit5/JsfSetupExtensionTest.java
+++ b/src/test/java/de/cuioss/test/jsf/junit5/JsfSetupExtensionTest.java
@@ -25,8 +25,6 @@ import lombok.Setter;
 import org.apache.myfaces.test.config.ResourceBundleVarNames;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 @JsfTestConfiguration(BasicApplicationConfiguration.class)
@@ -80,7 +78,7 @@ class JsfSetupExtensionTest implements JsfEnvironmentConsumer {
     }
 
     @Test
-    void shouldAssertRedirect() throws IOException {
+    void shouldAssertRedirect() throws Exception {
         getExternalContext().redirect(TO_VIEW_JSF);
         assertRedirect(TO_VIEW_JSF);
     }

--- a/src/test/java/de/cuioss/test/jsf/junit5/NavigationAssertsTest.java
+++ b/src/test/java/de/cuioss/test/jsf/junit5/NavigationAssertsTest.java
@@ -21,8 +21,6 @@ import jakarta.faces.context.FacesContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -80,7 +78,7 @@ class NavigationAssertsTest {
     @Test
     void shouldAssertRedirect(
         ExternalContext externalContext,
-        NavigationAsserts navigationAsserts) throws IOException {
+        NavigationAsserts navigationAsserts) throws Exception {
         // Perform redirect
         externalContext.redirect("/test/url");
 
@@ -95,7 +93,7 @@ class NavigationAssertsTest {
     @Test
     void shouldFailWhenRedirectUrlDoesntMatch(
         ExternalContext externalContext,
-        NavigationAsserts navigationAsserts) throws IOException {
+        NavigationAsserts navigationAsserts) throws Exception {
         // Perform redirect
         externalContext.redirect("/test/url");
 

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockSearchExpressionContextFactoryTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockSearchExpressionContextFactoryTest.java
@@ -18,7 +18,7 @@ package de.cuioss.test.jsf.mocks;
 import de.cuioss.test.jsf.util.ConfigurableFacesTest;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -35,7 +35,7 @@ class CuiMockSearchExpressionContextFactoryTest extends ConfigurableFacesTest {
         var factory = CuiMockSearchExpressionContextFactory.retrieve();
 
         var inlineCreated = factory.getSearchExpressionContext(getFacesContext(), new CuiMockComponent(),
-            Collections.emptySet(), Collections.emptySet());
+            Set.of(), Set.of());
 
         assertNotNull(inlineCreated.getVisitHints());
 
@@ -43,7 +43,7 @@ class CuiMockSearchExpressionContextFactoryTest extends ConfigurableFacesTest {
             new CuiMockSearchExpressionContext(new CuiMockComponent(), getFacesContext(), null, null));
 
         var preconfigured = factory.getSearchExpressionContext(getFacesContext(), new CuiMockComponent(),
-            Collections.emptySet(), Collections.emptySet());
+            Set.of(), Set.of());
 
         assertNull(preconfigured.getVisitHints());
     }

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiSearchExpressionHandlerMockTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiSearchExpressionHandlerMockTest.java
@@ -20,7 +20,7 @@ import jakarta.faces.component.search.ComponentNotFoundException;
 import jakarta.faces.component.search.SearchExpressionHint;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.Set;
 
 import static de.cuioss.tools.collect.CollectionLiterals.mutableList;
 import static de.cuioss.tools.collect.CollectionLiterals.mutableSet;
@@ -38,7 +38,7 @@ class CuiSearchExpressionHandlerMockTest extends ConfigurableFacesTest {
     @Test
     void shouldIgnoreHint() {
         var context = new CuiMockSearchExpressionContext(new CuiMockComponent(), getFacesContext(),
-            Collections.emptySet(), mutableSet(SearchExpressionHint.IGNORE_NO_RESULT));
+            Set.of(), mutableSet(SearchExpressionHint.IGNORE_NO_RESULT));
         var callback = new CuiMockContextCallback();
 
         assertNull(new CuiMockSearchExpressionHandler().resolveClientId(context, EXPRESSION));
@@ -54,7 +54,7 @@ class CuiSearchExpressionHandlerMockTest extends ConfigurableFacesTest {
     @Test
     void shouldFailOnMissingHint() {
         var context = new CuiMockSearchExpressionContext(new CuiMockComponent(), getFacesContext(),
-            Collections.emptySet(), Collections.emptySet());
+            Set.of(), Set.of());
         var handler = new CuiMockSearchExpressionHandler();
         var callback = new CuiMockContextCallback();
         assertThrows(ComponentNotFoundException.class, () -> handler.resolveComponents(context, EXPRESSION, callback));
@@ -63,7 +63,7 @@ class CuiSearchExpressionHandlerMockTest extends ConfigurableFacesTest {
     @Test
     void shouldCallBack() {
         var context = new CuiMockSearchExpressionContext(new CuiMockComponent(), getFacesContext(),
-            Collections.emptySet(), Collections.emptySet());
+            Set.of(), Set.of());
         var callback = new CuiMockContextCallback();
 
         var component = new CuiMockComponent();

--- a/src/test/java/de/cuioss/test/jsf/renderer/AbstractRendererTestBaseTest.java
+++ b/src/test/java/de/cuioss/test/jsf/renderer/AbstractRendererTestBaseTest.java
@@ -23,8 +23,6 @@ import lombok.Getter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 class AbstractRendererTestBaseTest extends AbstractRendererTestBase<CuiMockRenderer> {
@@ -41,7 +39,7 @@ class AbstractRendererTestBaseTest extends AbstractRendererTestBase<CuiMockRende
     }
 
     @Test
-    void shouldRenderGoodCase(FacesContext facesContext) throws IOException {
+    void shouldRenderGoodCase(FacesContext facesContext) throws Exception {
         assertEquals(RENDER_RESULT, assertDoesNotThrow(() -> renderToString(component, facesContext)));
         assertRenderResult(component, RENDER_RESULT, facesContext);
         assertRenderResult(component, DomUtils.htmlStringToDocument(RENDER_RESULT), facesContext);

--- a/src/test/java/de/cuioss/test/jsf/util/ConfigurableFacesTestTest.java
+++ b/src/test/java/de/cuioss/test/jsf/util/ConfigurableFacesTestTest.java
@@ -26,8 +26,6 @@ import de.cuioss.test.jsf.config.decorator.RequestConfigDecorator;
 import de.cuioss.test.jsf.defaults.BasicApplicationConfiguration;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import static de.cuioss.test.jsf.defaults.BasicApplicationConfiguration.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -91,7 +89,7 @@ class ConfigurableFacesTestTest extends ConfigurableFacesTest
     }
 
     @Test
-    void shouldHandleRedirect() throws IOException {
+    void shouldHandleRedirect() throws Exception {
         getExternalContext().redirect(TO_VIEW_JSF);
         assertRedirect(TO_VIEW_JSF);
     }

--- a/src/test/java/de/cuioss/test/jsf/util/JsfTestSetupDispatchTest.java
+++ b/src/test/java/de/cuioss/test/jsf/util/JsfTestSetupDispatchTest.java
@@ -24,9 +24,7 @@ import de.cuioss.test.jsf.junit5.EnableJsfEnvironment;
 import jakarta.faces.context.FacesContext;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Verifies that a bare {@link JsfTestSetup} implementor — one that does <em>not</em>

--- a/src/test/java/de/cuioss/test/jsf/util/JsfTestSetupDispatchTest.java
+++ b/src/test/java/de/cuioss/test/jsf/util/JsfTestSetupDispatchTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.util;
+
+import de.cuioss.test.jsf.config.JsfTestConfiguration;
+import de.cuioss.test.jsf.config.JsfTestSetup;
+import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
+import de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator;
+import de.cuioss.test.jsf.config.decorator.RequestConfigDecorator;
+import de.cuioss.test.jsf.junit5.EnableJsfEnvironment;
+import jakarta.faces.context.FacesContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a bare {@link JsfTestSetup} implementor — one that does <em>not</em>
+ * also implement any of the legacy configurator sub-interfaces — has all three
+ * {@code configure*} default methods dispatched by {@code ConfigurationHelper}.
+ */
+@EnableJsfEnvironment
+@JsfTestConfiguration(JsfTestSetupDispatchTest.BareSetup.class)
+class JsfTestSetupDispatchTest {
+
+    @Test
+    void shouldDispatchAllThreeConfigureMethodsForBareSetup(FacesContext facesContext) {
+        assertNotNull(facesContext);
+        assertAll("bare JsfTestSetup dispatch",
+            () -> assertTrue(BareSetup.applicationCalled, "configureApplication should be dispatched"),
+            () -> assertTrue(BareSetup.componentsCalled, "configureComponents should be dispatched"),
+            () -> assertTrue(BareSetup.requestCalled, "configureRequest should be dispatched"));
+    }
+
+    /**
+     * A configuration class implementing only {@link JsfTestSetup}, overriding all three
+     * configure methods to record that each was dispatched.
+     */
+    public static class BareSetup implements JsfTestSetup {
+
+        static boolean applicationCalled;
+        static boolean componentsCalled;
+        static boolean requestCalled;
+
+        @Override
+        public void configureApplication(ApplicationConfigDecorator applicationConfig) {
+            applicationCalled = true;
+        }
+
+        @Override
+        public void configureComponents(ComponentConfigDecorator componentConfig) {
+            componentsCalled = true;
+        }
+
+        @Override
+        public void configureRequest(RequestConfigDecorator requestConfig) {
+            requestCalled = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `JsfTestSetup` as a non-deprecated replacement for the `JsfTestContextConfigurator` hierarchy in the `@JsfTestConfiguration` context.

`@JsfTestConfiguration.value()` previously required `Class<? extends JsfTestContextConfigurator>[]`, but `JsfTestContextConfigurator` and all three of its sub-interfaces (`ApplicationConfigurator`, `ComponentConfigurator`, `RequestConfigurator`) were `@Deprecated`. This forced every `@JsfTestConfiguration` consumer to add `@SuppressWarnings("java:S1874")` just to reference the configurator types in the annotation value.

The change introduces `JsfTestSetup` as the new non-deprecated annotation bound with three default no-op methods (`configureApplication`, `configureComponents`, `configureRequest`), re-parents the legacy sub-interfaces onto `JsfTestSetup` for backward compatibility, and migrates `BasicApplicationConfiguration` to implement `JsfTestSetup` directly.

## Changes

- `src/main/java/de/cuioss/test/jsf/config/JsfTestSetup.java` — new non-deprecated interface with three default methods matching the decorator signatures
- `src/main/java/de/cuioss/test/jsf/config/ApplicationConfigurator.java` — re-parented: `extends JsfTestSetup` (was `extends JsfTestContextConfigurator`), added `@Override`
- `src/main/java/de/cuioss/test/jsf/config/ComponentConfigurator.java` — re-parented: `extends JsfTestSetup`, added `@Override`
- `src/main/java/de/cuioss/test/jsf/config/RequestConfigurator.java` — re-parented: `extends JsfTestSetup`, added `@Override`
- `src/main/java/de/cuioss/test/jsf/config/JsfTestConfiguration.java` — annotation bound changed to `Class<? extends JsfTestSetup>[]`
- `src/main/java/de/cuioss/test/jsf/config/JsfTestSetup.java` — new interface
- `src/main/java/de/cuioss/test/jsf/util/ConfigurationHelper.java` — broadened dispatch: bare `JsfTestSetup` implementors now have all three default methods invoked; legacy sub-interface dispatch preserved without double-invocation
- `src/main/java/de/cuioss/test/jsf/defaults/BasicApplicationConfiguration.java` — migrated from `implements ApplicationConfigurator, RequestConfigurator` to `implements JsfTestSetup`
- `doc/migration/4.3.adoc` — new migration guide documenting the `JsfTestSetup` annotation target
- `README.adoc` — added `link:doc/migration/4.3.adoc[Migration Guide to 4.3]` to the documentation index
- `pom.xml` — version bump for 4.3-SNAPSHOT

## Test Plan

- [x] `./mvnw test` passed — all existing tests green
- [x] `@JsfTestConfiguration(BasicApplicationConfiguration.class)` compiles without `@SuppressWarnings("java:S1874")`
- [x] Backward compatibility confirmed: existing classes implementing legacy sub-interfaces compile and pass unchanged
- [x] `ConfigurationHelper` dispatches all three methods for bare `JsfTestSetup` implementors

## Related Issues

Closes #74
