### PR TITLE
refactor(codebase): apply profile standards across java codebase

### DIFF
--- a/src/main/java/de/cuioss/test/jsf/config/JsfTestConfiguration.java
+++ b/src/main/java/de/cuioss/test/jsf/config/JsfTestConfiguration.java
@@ -29,14 +29,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * should implement {@link JsfTestSetup} and override only the methods they
  * need. This is useful for cases where a certain configuration is reused
  * across multiple test classes.
- * 
+ *
  * <p>
  * This annotation can be applied at both the type level (class) and method level.
  * When applied at the method level, the configuration will only be applied for that
  * specific test method. When applied at both levels, the method-level configuration
  * takes precedence over the class-level configuration.
  * </p>
- * 
+ *
  * <p>
  * For nested test classes, the annotation can be applied to the nested class,
  * and it will take precedence over any annotation on the parent class.

--- a/src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironment.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironment.java
@@ -183,7 +183,7 @@ public @interface EnableJsfEnvironment {
      * When true, the IdentityResourceBundle will be used which returns the message key
      * itself instead of looking up the actual message. This is useful for testing
      * that the correct message key is used without testing the ResourceBundle mechanism.
-     * 
+     *
      * @return true if the IdentityResourceBundle should be used, false otherwise
      */
     boolean useIdentityResourceBundle() default true;

--- a/src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironments.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironments.java
@@ -35,7 +35,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
     /**
      * Returns the array of EnableJsfEnvironment annotations that are contained
      * within this repeatable annotation container.
-     * 
+     *
      * @return an array of {@link EnableJsfEnvironment} annotations to be applied
      */
     EnableJsfEnvironment[] value();

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockUIViewRoot.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockUIViewRoot.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import static de.cuioss.tools.collect.CollectionLiterals.mutableMap;
 
 /**
- * Mock variant of {@link UIViewRoot} providing a heloer for adding a
+ * Mock variant of {@link UIViewRoot} providing a helper for adding a
  * {@link UIComponent} at runtime
  *
  * @author Oliver Wolff

--- a/src/main/java/de/cuioss/test/jsf/renderer/AbstractComponentRendererTest.java
+++ b/src/main/java/de/cuioss/test/jsf/renderer/AbstractComponentRendererTest.java
@@ -85,7 +85,7 @@ public abstract class AbstractComponentRendererTest<R extends Renderer> extends 
     /**
      * Iterates through all active RendererAttributeAssert and tests them
      * accordingly.
-     * 
+     *
      * @param facesContext the FacesContext to be used for rendering
      */
     @Test


### PR DESCRIPTION
## Summary

Apply the "Refactor to Profile Standards" recipe across the cui-jsf-test-basic
production codebase (15 package deliverables audited). The codebase was already
largely standards-compliant following prior OpenRewrite cleanup, so the net
change is minimal: a JavaDoc typo fix in the mocks package and trailing-whitespace
removals in renderer, config, and junit5. The remaining 11 packages audited clean
with no changes required.

## Changes

- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockUIViewRoot.java` — fix JavaDoc
  typo (spurious duplicate word in method comment)
- `src/main/java/de/cuioss/test/jsf/renderer/AbstractComponentRendererTest.java` —
  remove trailing whitespace
- `src/main/java/de/cuioss/test/jsf/config/JsfTestConfiguration.java` — remove
  trailing whitespace
- `src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironment.java` — remove
  trailing whitespace
- `src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironments.java` — remove
  trailing whitespace

## Test Plan

- [ ] Verification command passed (`./mvnw clean install`)
- [ ] Manual testing completed (if applicable)

## Related Issues

N/A
