### PR TITLE
chore(config): migrate marshal.json to final_merge_without_asking

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -51,7 +51,7 @@
       "pr_merge_strategy": "squash",
       "finalize_without_asking": true,
       "loop_back_without_asking": false,
-      "auto_merge_after_ci": true,
+      "final_merge_without_asking": false,
       "self_review": "auto",
       "qgate": "auto",
       "plugin_doctor": "auto",


### PR DESCRIPTION
## Summary

Rename the phase-6-finalize merge knob in `.plan/marshal.json`:

```
plan.phase-6-finalize.auto_merge_after_ci  ->  plan.phase-6-finalize.final_merge_without_asking
```

Follows the plan-marshall schema rename (lesson `2026-06-16-10-001`, plan-marshall PR #703).

## Value: false (new safe default)

The prior `true` was the *old schema default* — seeded automatically, not a conscious opt-in
to unattended merge. The renamed knob is set to `false` so the finalize pre-merge gate now
prompts before the irreversible merge to `main`. To restore unattended auto-merge, set
`final_merge_without_asking: true` explicitly.

Polarity is unchanged (`true` = merge without asking); only the default behavior flips for
this project from auto-merge to prompt-before-merge.
