### PR TITLE
chore(config): remove dead plugin_doctor finalize gate from marshal.json

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -54,7 +54,6 @@
       "final_merge_without_asking": false,
       "self_review": "auto",
       "qgate": "auto",
-      "plugin_doctor": "auto",
       "simplify": "auto",
       "checks_wait_timeout_seconds": 600,
       "auto_rebase_threshold": "no_overlap_only",


### PR DESCRIPTION
The plugin_doctor finalize-gate knob was removed from plan-marshall's domain-invariant defaults (it gates a marketplace-component lint with no consumer applicability). This consumer project inherited the dead knob from the old defaults; this PR removes it. The self_review / qgate / simplify gates are unchanged.