### PR TITLE
chore(plan-marshall): migrate marshal.json to verification_steps schema

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -33,12 +33,15 @@
     "phase-5-execute": {
       "commit_and_push": true,
       "max_iterations": 5,
-      "per_deliverable_build": "compile+scoped-test",
+      "per_deliverable_build": [
+        "default:verify:compile",
+        "default:verify:module-tests"
+      ],
       "per_task_budget_reserve_tokens": "50K",
-      "steps": [
-        "default:quality_check",
-        "default:build_verify",
-        "default:coverage_check"
+      "verification_steps": [
+        "default:verify:quality-gate",
+        "default:verify:module-tests",
+        "default:verify:coverage"
       ],
       "effort": {
         "default": "level-4",


### PR DESCRIPTION
Adopts the new plan-marshall canonical-verify config schema (plan-marshall PR #707): renames `plan.phase-5-execute.steps` to `verification_steps` with `default:verify:{canonical}` IDs (quality-gate, module-tests, coverage), and converts `per_deliverable_build` from the retired enum to a module-scoped list. No integration-tests/e2e steps are added (this project defines no such Maven profile).