### PR TITLE
chore(plan): migrate architecture skill names to the persona/ref/profile rename

### DIFF
--- a/.plan/project-architecture/cui-jsf-test-basic/enriched.json
+++ b/.plan/project-architecture/cui-jsf-test-basic/enriched.json
@@ -14,11 +14,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -31,15 +31,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -56,11 +56,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",


### PR DESCRIPTION
plan-marshall renamed three foundation skills in [PR #759](https://github.com/cuioss/plan-marshall/pull/759):

- `dev-agent-behavior-rules` → `persona-plan-marshall-agent`
- `dev-general-module-testing` → `persona-module-tester`
- `dev-general-code-quality` → `ref-code-quality`

This updates the `skills_by_profile` notations in the cached architecture record (`.plan/project-architecture/cui-jsf-test-basic/enriched.json`) so plan dispatch resolves the renamed skills instead of the now-deleted names. Pure notation rename — the resolved skill set is unchanged.

Docs/config-only; no source changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated skill profile configurations to enhance system consistency across implementation, testing, and quality workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->