### PR TITLE
chore(config): migrate finalize step default:commit-push to default:push

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -60,7 +60,7 @@
       "steps": {
         "default:pre-push-quality-gate": {},
         "default:finalize-step-whole-tree-gate": {},
-        "default:commit-push": {},
+        "default:push": {},
         "default:finalize-step-simplify": {},
         "default:create-pr": {},
         "default:ci-verify": {},


### PR DESCRIPTION
Mirrors the upstream plan-marshall rename (PR cuioss/plan-marshall#765): the `commit-push` finalize step became a pure `push` barrier (`default:push`). Renames the `default:commit-push` key to `default:push` in this consumer's `.plan/marshal.json` phase_6 step set so the manifest composer resolves the step. The simplify-before-push ordering is handled by the composer via step frontmatter `order:`, so no key reordering is needed here.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal workflow configuration for the build and deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->