### PR TITLE
chore(config): order finalize-step-simplify before push on disk

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -60,8 +60,8 @@
       "steps": {
         "default:pre-push-quality-gate": {},
         "default:finalize-step-whole-tree-gate": {},
-        "default:push": {},
         "default:finalize-step-simplify": {},
+        "default:push": {},
         "default:create-pr": {},
         "default:ci-verify": {},
         "default:automated-review": {


### PR DESCRIPTION
Follow-up to the commit-push->push rename (#122). Reorders the `.plan/marshal.json` phase_6 step keys so `default:finalize-step-simplify` (frontmatter order 8) appears before `default:push` (order 10), matching the new model where simplify runs and is committed before the push barrier. The manifest composer already sorts by frontmatter `order:`, so this is a display-order alignment that keeps the persisted key order from misleading readers.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal build process execution sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->