### PR TITLE
chore(config): seed finalize-step-sync-baseline in phase-6 candidate set

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -58,6 +58,9 @@
       "checks_wait_timeout_seconds": 600,
       "drop_review_on_scope_gate": false,
       "steps": {
+        "default:finalize-step-sync-baseline": {
+          "auto_rebase_threshold": "no_overlap_only"
+        },
         "default:pre-push-quality-gate": {},
         "default:finalize-step-whole-tree-gate": {},
         "default:finalize-step-simplify": {},


### PR DESCRIPTION
Propagates the new plan-marshall default finalize step `default:finalize-step-sync-baseline` (order 3) into this repo's phase-6-finalize candidate set.

The step performs a pure-local rebase of the worktree feature branch onto `origin/main` at the **start** of finalize, so the local quality gates and CI validate the actual to-be-landed (rebased) tree instead of a stale base. It reuses existing git verbs (`baseline-reconcile` + `worktree-rebase-to`), does no force-push and no CI wait at that order, and carries the `auto_rebase_threshold` conflict-gate param (default `no_overlap_only`). Inserted before `default:pre-push-quality-gate`.

Upstream: cuioss/plan-marshall#786.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the finalization workflow so it better handles cases with no overlapping changes, helping reduce unnecessary rework before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->