### PR TITLE
docs: add full project review and fix plan (review-26-07-04)

### DIFF
--- a/doc/review-26-07-04.md
+++ b/doc/review-26-07-04.md
@@ -1,0 +1,458 @@
+# Project Review & Fix Plan — 2026-07-04
+
+Full-project analysis of `cui-jsf-test-basic` (state: `main`, 4.4-SNAPSHOT, 228 tests green).
+This document contains **all findings** with fix hints, **partitioned into PR clusters**, plus the
+**workflow to execute per PR** and a **final verification step**. The review covered every file in
+`src/main/java`, `src/test/java`, `pom.xml`, `.github/`, `.mvn/`, and all documentation.
+
+Severity: **[C]** critical · **[M]** major · **[m]** minor.
+Each finding has a stable ID (`<CLUSTER>-<n>`) for tracking. Line numbers refer to the state at review time.
+
+---
+
+## Summary
+
+| Cluster | PR | Findings | Severity profile |
+|---|---|---|---|
+| 1. Mock behavior correctness | PR-1 | MOCK-1 … MOCK-14 | 4×M, 10×m |
+| 2. Lifecycle & configuration infrastructure | PR-2 | LIFE-1 … LIFE-9 | 5×M, 4×m |
+| 3. Assertion & test-base robustness | PR-3 | ASSERT-1 … ASSERT-12 | 12×m |
+| 4. Public-API naming (deprecation path) | PR-4 | API-1 … API-5 | 5×m |
+| 5. Build, dependencies & CI | PR-5 | BUILD-1 … BUILD-10 | 1×M, 9×m |
+| 6. Test-suite quality & coverage | PR-6 | TEST-1 … TEST-8 | 3×M, 5×m |
+| 7. Documentation & Javadoc | PR-7 | DOC-1 … DOC-15 | 3×C, 2×M, 10×m |
+| 8. Final verification & cleanup | PR-8 | — | removes this document |
+
+Recommended execution order: **PR-1 → PR-2 → PR-3 → PR-4 → PR-5 → PR-6 → PR-7 → PR-8**.
+PR-6 partially depends on PR-1/PR-2 (tests for fixed behavior); PR-7 goes last so docs describe the final state.
+PR-1 through PR-5 are mutually independent and could be done in any order.
+
+> **Behavior-change warning:** MOCK-1, MOCK-2, MOCK-4, LIFE-2, LIFE-3 change observable behavior that
+> downstream consumers may (accidentally) depend on. Each of these fixes must be called out in the
+> release notes / migration doc for the next release.
+
+---
+
+## Cluster 1 — Mock behavior correctness (PR-1)
+
+Branch suggestion: `fix/mock-behavior`. These are spec/contract violations in the mock layer —
+the core product of this library — that can make consumer tests silently pass or fail wrongly.
+
+### MOCK-1 [M] `CuiMockResourceHandler.libraryExists` logic is inverted
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandler.java:130-132`
+- `return LIBRARY_NOT_THERE.equals(libraryName);` returns `true` only for the sentinel `"libNotThere"` and `false` for every real library.
+- **Fix:** `return !LIBRARY_NOT_THERE.equals(libraryName);` (or check against registered `availableResouces` keys). Add a regression test.
+
+### MOCK-2 [M] `CuiMockConfigurableNavigationHandler.handleNavigation` reports success for unknown outcomes
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockConfigurableNavigationHandler.java:79-96`
+- For an outcome with no matching navigation case, it still redirects to the raw outcome string, sets the view id, and marks `handleNavigationCalled = true` — so `NavigationAsserts.assertNavigatedWithOutcome("typo")` passes for outcomes that were never registered. JSF spec: no matching case → stay on current view.
+- **Fix:** when `navigationCase == null`, do not redirect and do not set the tracking flags (or at minimum keep `handleNavigationCalled == false`). Add a test asserting an unknown outcome does NOT count as navigation.
+
+### MOCK-3 [m] Non-redirect navigation cases executed as redirects
+- Same file, lines 86-89. `navigationCase.isRedirect()` is never consulted; every registered case commits a redirect response.
+- **Fix:** call `externalContext.redirect(...)` only when `navigationCase.isRedirect()`.
+
+### MOCK-4 [M] `CuiMockHttpSession.invalidate()` never invalidates
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpSession.java:47-52`
+- Override removes attributes but never calls `super.invalidate()` — the base `invalid` flag is never set, subsequent `get/setAttribute` succeed instead of throwing `IllegalStateException`, and `HttpSessionListener.sessionDestroyed` is never fired (asymmetric with `sessionCreated`).
+- **Fix:** call `super.invalidate()` (super already clears attributes; the manual clearing can go).
+
+### MOCK-5 [M] `CuiMockViewHandler.registerCompositeComponent` fails on second invocation
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockViewHandler.java:47-51`
+- Each call ends with `EasyMock.replay(mock)`; a second registration calls `expect(...)` on a replayed mock → `IllegalStateException`. `ComponentConfigDecorator.registerCompositeComponent` (lines 388-396) therefore supports exactly one composite component per test.
+- **Fix:** replace the EasyMock construction with a small hand-written `ViewDeclarationLanguage` stub holding a `Map<(library, tagName), UIComponent>`. Add a test registering two composite components.
+
+### MOCK-6 [m] `CuiMockHttpServletRequest.getSession(false)` violates the servlet contract
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequest.java:123-150`
+- With `create == false` an invalidated session is silently replaced by a fresh one; foreign (non-`CuiMockHttpSession`) sessions are discarded (attributes lost) even when `create == false`.
+- **Fix:** return `null` in the `!create` path when the session is invalidated; preserve/wrap foreign sessions instead of replacing them.
+
+### MOCK-7 [m] `CuiMockHttpServletRequest.getLocales()` may return an empty enumeration
+- Same file, lines 46-57. Servlet spec requires at least the server default locale.
+- **Fix:** fall back to `Locale.getDefault()` when the configured list is empty. (See also LIFE-9 / `RequestConfigDecorator.setRequestLocale()` with zero args.)
+
+### MOCK-8 [m] `CuiMockUIViewRoot.getViewMap(false)` never returns null
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockUIViewRoot.java:57-60`
+- JSF contract: `getViewMap(false)` returns `null` when no map exists. Always returning it hides create-on-demand bugs.
+- **Fix:** track creation state, or document the deviation in the class Javadoc.
+
+### MOCK-9 [m] `ReverseConverter.getAsObject` returns `""` for null input
+- `src/main/java/de/cuioss/test/jsf/mocks/ReverseConverter.java:53-55`
+- Converter contract is to return `null` for null/empty input; returning `""` can mask required-field handling.
+- **Fix:** return `null` for null/empty input.
+
+### MOCK-10 [m] `CuiMockMethodExpression.invoke` NPEs on null params
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockMethodExpression.java:76-79`
+- EL API explicitly allows `params == null` for zero-arg methods.
+- **Fix:** `invokedParams = params == null ? new Object[0] : Arrays.copyOf(params, params.length);`
+
+### MOCK-11 [m] `CuiMockRenderer` writes `EditableValueHolder` value without null check
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockRenderer.java:86`
+- Every other branch guards against null; a spec-compliant `ResponseWriter` requires non-null values → NPE when rendering an input without value.
+- **Fix:** add the same null guard as the sibling branches.
+
+### MOCK-12 [m] `CuiMockResourceHandler.getRendererTypeForResourceName` never returns null
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandler.java:145-147`
+- Spec expects `null` when no renderer type matches; returning `resourceName + "-rendererererer"` makes every resource appear renderable.
+- **Fix:** return null for unknown resources, or document the deviation.
+
+### MOCK-13 [m] `CuiMockSearchExpressionHandler.shouldIgnoreNoResult` name is inverted
+- `src/main/java/de/cuioss/test/jsf/mocks/CuiMockSearchExpressionHandler.java:118-121`
+- Returns `true` when hints do NOT contain `IGNORE_NO_RESULT`. Callers are correct, but the name invites future bugs. Also line 106: `requireNonNull` without message.
+- **Fix:** rename to `shouldFailOnNoResult` (private method — safe), add a message to the null check.
+
+### MOCK-14 [m] Misc mock nits
+- `CuiMockServletContext.java:38` — default `contextPath = "mock-context"` lacks the spec-required leading `/`.
+- `CuiMockContextCallback.java:46-48` — `assertNotCalledAtAll()` Javadoc is copy-pasted from `assertCalledAtLeastOnce` and says the opposite of what the method checks.
+- `CuiMockConfigurableNavigationHandler.java:106-112, 122-131` — `addNavigationCase(outcome, case)` delegates to the 3-arg overload, so both tracking flags are always set (asserting "fromAction variant NOT used" is impossible); line 127 has a redundant `remove` before `put`.
+- `CuiMockConfigurableNavigationHandler.java:40-41, 58-60` — `getNavigationCases()` map is keyed `"fromAction|outcome"`, spec keys by from-view-id; document the deviation.
+- `CuiMockViewHandler.java:28-29` — garbled Javadoc ("have not other use but being defined").
+- **Fix:** straightforward per bullet; fromAction flag: set `addNavigationWithFromActionCalled` only when `fromAction != null`.
+
+**PR-1 verification:** new regression tests for MOCK-1, MOCK-2, MOCK-4, MOCK-5; full `./mvnw clean install`.
+
+---
+
+## Cluster 2 — Lifecycle & configuration infrastructure (PR-2)
+
+Branch suggestion: `fix/lifecycle-configuration`. Bugs in the JUnit-5 extension and configuration
+dispatch that cause nondeterminism, double execution, and resource leaks.
+
+### LIFE-1 [M] `JsfSetupExtension` destroys deliberate configuration ordering
+- `src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java:137, 291`
+- `decoratorAnnotations.stream().filter(Objects::nonNull).collect(Collectors.toSet())` re-collects a purpose-built `LinkedHashSet` into an unordered `HashSet` — multiple `@JsfTestConfiguration` classes are applied in nondeterministic order; when two configurations touch the same registration the winner varies between JVM runs.
+- **Fix:** `Collectors.toCollection(LinkedHashSet::new)` (the non-null filter is unnecessary). Add a test with two configurations overriding the same navigation case asserting deterministic last-wins order.
+
+### LIFE-2 [M] Class-level `@JsfTestConfiguration` applied twice per test
+- Same file, lines 139-141 vs 289-309 (with fallback at 180-189).
+- `postProcessTestInstance` applies class-level configurations; `beforeEach` re-resolves annotations with a class-level fallback and applies them again — non-idempotent configurators run twice per test.
+- **Fix:** in `beforeEach`, apply configurations only when *method-level* annotations were actually found. Add a counting-configurator regression test.
+
+### LIFE-3 [M] `ConfigurableFacesTest` never tears down the JSF runtime
+- `src/main/java/de/cuioss/test/jsf/util/ConfigurableFacesTest.java` (only `@BeforeEach` at 94-121, no `@AfterEach`)
+- `runtimeSetup.tearDown()` is never invoked: `MockFacesContext` is never released (thread-local leaks into later tests), `FactoryFinder` factories stay registered, and the thread-context classloader is never restored.
+- **Fix:** add `@AfterEach protected void tearDownJsfRuntime() { runtimeSetup.tearDown(); }` (mirror `JsfSetupExtension.afterEach`).
+
+### LIFE-4 [M] `ConfigurationHelper` silently loses phases for mixed legacy/new configurators
+- `src/main/java/de/cuioss/test/jsf/util/ConfigurationHelper.java:80-88, 107-115, 134-142 vs 177-189`
+- A configuration class implementing one deprecated interface (e.g. `ApplicationConfigurator`) **and** overriding another `JsfTestSetup` default (e.g. `configureComponents`) is excluded from both dispatch paths for the other phases — its override is silently never called.
+- **Fix:** in `getBareJsfTestSetups`, exclude per-phase (for the components phase exclude only `ComponentConfigurator` implementors, etc.), or dispatch everything through `JsfTestSetup`. Add a mixed-configurator regression test.
+
+### LIFE-5 [M] `AbstractConverterTest.configureComponents` is a documented no-op
+- `src/main/java/de/cuioss/test/jsf/converter/AbstractConverterTest.java:136-153`
+- Javadoc sells it as a "Callback method … at the correct time", but the class does not implement `ComponentConfigurator` and `ConfigurationHelper` dispatches only on that interface — the default `registerMockRenderer(...)` never runs, and subclass overrides are silent no-ops.
+- **Fix:** make `AbstractConverterTest` implement `ComponentConfigurator` (deprecation-tolerant), or invoke the method explicitly from `initConverter()` with a decorator built from the current context. Add a test proving an override is called.
+
+### LIFE-6 [m] Test class implementing bare `JsfTestSetup` gets no callbacks
+- `ConfigurationHelper.java:82-84` (and analogues) — only `instanceof ApplicationConfigurator/ComponentConfigurator/RequestConfigurator` is honored for the test instance itself; a test class that migrated to the advertised replacement `JsfTestSetup` silently gets nothing.
+- **Fix:** also dispatch on `testClass instanceof JsfTestSetup`. Document ordering; align the "called after the others" Javadoc (lines 64-67) with actual order, and note that each configured class is instantiated once **per phase** (lines 151-162/177-189) so implementations must be stateless.
+
+### LIFE-7 [m] `@Repeatable` containers not method-applicable
+- `src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironments.java:31` — container targets only `TYPE` while `EnableJsfEnvironment` targets `{TYPE, METHOD}`.
+- `src/main/java/de/cuioss/test/jsf/config/JsfTestConfigurations.java:30` — same defect; a repeated `@JsfTestConfiguration` on a test method is a compile error although the Javadoc advertises method-level use.
+- **Fix:** add `METHOD` to both containers' `@Target`.
+
+### LIFE-8 [m] `JsfRuntimeSetup` resource hygiene
+- `src/main/java/de/cuioss/test/jsf/util/JsfRuntimeSetup.java:147-151, 291-297, 121-140`
+- The per-setup `URLClassLoader` is never closed (S2095); `facesContextFactory` is not nulled in `tearDown`; repeated `setUp()` without `tearDown()` overwrites the saved thread-context classloader so the original can never be restored.
+- **Fix:** keep the loader reference and `close()` it in teardown; null `facesContextFactory`; guard `threadContextClassLoader` assignment.
+- Related: `JsfSetupExtension.java:118-119` — inline comment "Use the outermost annotation" contradicts the actual (correct) innermost-wins behavior; fix the comment. Also document (or guard) that `@TestInstance(PER_CLASS)` is unsupported: setup runs once per instance but `afterEach` tears down after every test.
+
+### LIFE-9 [m] `RequestConfigDecorator` rough edges
+- `src/main/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecorator.java`
+- Lines 145-155: `setRequestLocale()` with zero args sets `request.setLocale(null)` and an empty locale list (spec-violating request; see MOCK-7). Lines 158-166: `setQueryString` is the only decorator method returning `void` (breaks fluent chaining) and has an empty `@param`. Lines 89-92: `setRequestParameter` Javadoc copy-pastes `getRequestHeaderMap()` references; line 118 "the the" typo.
+- **Fix:** reject/fall back on empty locale input; return `this` from `setQueryString`; fix Javadoc.
+
+**PR-2 verification:** regression tests for LIFE-1, LIFE-2, LIFE-4, LIFE-5; full build; run the suite twice to spot ordering flakiness.
+
+---
+
+## Cluster 3 — Assertion & test-base robustness (PR-3)
+
+Branch suggestion: `fix/assertion-robustness`. Weaknesses in assertion helpers that mask failures
+or produce misleading diagnostics in consuming projects.
+
+### ASSERT-1 [m] `HtmlTreeAsserts` sorts live JDOM attribute lists (mutates caller documents)
+- `src/main/java/de/cuioss/test/jsf/renderer/util/HtmlTreeAsserts.java:109-110`
+- JDOM `getAttributes()` is a live list; sorting reorders both the expected and actual `Document`s — a reused expected document is silently modified.
+- **Fix:** copy to `new ArrayList<>(...)` before sorting.
+
+### ASSERT-2 [m] `HtmlTreeAsserts` NPEs before its own null assertions
+- Same file, line 66: `expected.getName()` is dereferenced before `assertNotNull` runs in `assertElementWithChildrenEquals`.
+- **Fix:** move the null asserts to the top of the method.
+
+### ASSERT-3 [m] Mixed-content text position not verified
+- Same file, lines 73-77: `getTextNormalize()` concatenates all direct text, so `<div>x<span/></div>` equals `<div><span/>x</div>`.
+- **Fix:** compare the `getContent()` sequence, or document the limitation in the class Javadoc.
+
+### ASSERT-4 [m] RENDERED assert passes on text-only output
+- `src/main/java/de/cuioss/test/jsf/renderer/CommonRendererAsserts.java:47-57`
+- The not-rendered check only fails when the parsed wrapper has child *elements*; bare text output passes despite `rendered=false`. The `null == element` guard (line 50) is dead code.
+- **Fix:** also assert `element.getTextTrim().isEmpty()`; remove the dead guard. Fix the copy-pasted STYLE_CLASS Javadoc (lines 62-64: says "style", means "styleClass").
+
+### ASSERT-5 [m] `AbstractRendererTestBase` misleading messages / dead throws
+- `src/main/java/de/cuioss/test/jsf/renderer/AbstractRendererTestBase.java`
+- Line 159: `assertNotNull(emptyToNull(expected), "Render result must not be empty.")` validates the caller-supplied *expected* string but blames the render result. Line 200: missing failure message on the second `assertThrows` (inconsistent with siblings). Lines 142-146/158-161: `throws IOException` is unreachable (calls wrapped in `assertDoesNotThrow`) and forces pointless `throws` clauses onto consumers.
+- **Fix:** message → "Expected HTML must not be empty"; add the missing message; drop the `throws` declarations.
+
+### ASSERT-6 [m] Converter/validator failure loops NPE instead of failing meaningfully
+- `src/main/java/de/cuioss/test/jsf/converter/AbstractConverterTest.java:239-245` and `src/main/java/de/cuioss/test/jsf/validator/AbstractValidatorTest.java:171-172`
+- `e.getFacesMessage()` is null when the exception was built from a plain string → bare NPE inside the catch masks the actual verification.
+- **Fix:** null-check and `fail("Exception carries no FacesMessage but message '<key>' was expected")`.
+
+### ASSERT-7 [m] `TestItems.roundtripValues` is a `HashSet`
+- `src/main/java/de/cuioss/test/jsf/converter/TestItems.java:66`
+- Nondeterministic iteration order and silent duplicate-dropping make order-dependent converter bugs non-reproducible.
+- **Fix:** use `LinkedHashSet` (or `List`).
+
+### ASSERT-8 [m] Dead `severity` data in converter/validator test items
+- `converter/TestItems.java:144, 158` + `ConverterTestItem`; `validator/TestItems.java:86` + `TestItem` — severity is stored on every invalid item but never asserted (`AbstractValidatorTest` hard-codes `SEVERITY_ERROR` at line 172).
+- **Fix:** either assert the stored severity in the failure loops or remove the field from the fluent path (prefer asserting — it's advertised API surface).
+
+### ASSERT-9 [m] `AbstractSanitizingConverterTest.shouldSanitizeJavaScript` NPE-prone, message-less
+- `src/main/java/de/cuioss/test/jsf/converter/AbstractSanitizingConverterTest.java:51-55`
+- NPEs if the converter returns null; `assertFalse` without message.
+- **Fix:** `assertNotNull(result, ...)` first; add an explanatory message to the `assertFalse`.
+
+### ASSERT-10 [m] `DomUtils` hardening and contract
+- `src/main/java/de/cuioss/test/jsf/renderer/util/DomUtils.java`
+- Lines 60-63: XXE hardening incomplete for strict Sonar S2755 — set `saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`. Lines 80/106: `requireNonNull(emptyToNull(...))` throws bare NPE for an *empty* string although the Javadoc says "must not be null nor empty" — throw `IllegalArgumentException` with a message.
+
+### ASSERT-11 [m] `NavigationAsserts` messages don't match the check
+- `src/main/java/de/cuioss/test/jsf/junit5/NavigationAsserts.java:83, 97`
+- Messages say "must not be null" but `emptyToNull` also rejects empty strings.
+- **Fix:** "must not be null or empty".
+
+### ASSERT-12 [m] Small cleanups flagged for a strict Sonar pass
+- `JsfParameterResolver.java:83-96` — mutable static `HashSet` for `SUPPORTED_TYPES`; use `Set.of(...)`.
+- `ComponentTestHelper.java:98-103` — dead `propertyType = null` initialization; `collectionType` always `NO_ITERABLE`; results funneled through a `HashMap` (line 72) making verification order nondeterministic — use `LinkedHashMap`.
+- `BasicApplicationConfiguration.java:74` — `new Locale[SUPPORTED_LOCALES.size()]` → `new Locale[0]`.
+- `AbstractConverterTest.java:98-99` / `AbstractValidatorTest.java:94-95` — leftover marker comment `// owolff we need to migrate this aspect later`; resolve or convert into a tracked issue.
+- `ServletObjectsFromJSFContextProducer.java:57` — commented-out `// @Typed({ ServletContext.class })`; restore or delete.
+
+**PR-3 verification:** new tests for ASSERT-1 (document reuse), ASSERT-4 (text-only output), ASSERT-6 (message-less exception); full build.
+
+---
+
+## Cluster 4 — Public-API naming, deprecation path (PR-4)
+
+Branch suggestion: `fix/api-naming-deprecations`. All published API — fix via **deprecate-and-replace**,
+never remove in the same release.
+
+### API-1 [m] `ComponentPropertyMetadata.isIgnoreOnValueExpresssion` (triple "s")
+- `src/main/java/de/cuioss/test/jsf/component/ComponentPropertyMetadata.java:43` (Lombok propagates the typo into the getter; `ValueExpressionPropertyContract:67` depends on it).
+- **Fix:** rename field to `ignoreOnValueExpression`, keep a `@Deprecated` bridge getter with the old name.
+
+### API-2 [m] `CuiMockResourceHandler.availableResouces` + Javadoc typos
+- `CuiMockResourceHandler.java:78` (public `getAvailableResouces()`), line 81 "resourceIdetnifier", lines 55-57 doc/constant mismatch (`"rendererererer"` vs `"-rendererererer"`).
+- **Fix:** add correctly-spelled accessors, deprecate the misspelled ones, fix docs.
+
+### API-3 [m] `ReverseConverter.CONVERTER_ID = "…ReserveConverter"`
+- `src/main/java/de/cuioss/test/jsf/mocks/ReverseConverter.java:38` — id says "Reserve", class is "Reverse"; by-convention lookups miss.
+- **Fix:** introduce the correct id, keep registering the old one too for one release, deprecate the old constant.
+
+### API-4 [m] `JsfProvidedConverter` — stale contract claim + leaky package-private type
+- `src/main/java/de/cuioss/test/jsf/generator/JsfProvidedConverter.java:30-37, 43, 61`
+- Javadoc claims it "acts as … ComponentConfigurator" but it implements only `TypedGenerator` (users configuring `@JsfTestConfiguration(JsfProvidedConverter.class)` get nothing). Public constants `JSF_CONVERTER` / `CONVERTER_CLASS_GERNERATOR` (note typo) expose package-private `ConverterDescriptor`, making the API unusable outside the package.
+- **Fix:** fix the Javadoc; make `ConverterDescriptor` public (it already has getters); add a correctly-named constant and deprecate `CONVERTER_CLASS_GERNERATOR`.
+
+### API-5 [m] Dead marker interface `JsfTestContextConfigurator`
+- `src/main/java/de/cuioss/test/jsf/config/JsfTestContextConfigurator.java:27` — nothing implements it; Javadoc claims the configurator interfaces extend it, but they extend `JsfTestSetup`.
+- **Fix:** it is already deprecated — schedule removal for the next major, and correct the referencing docs now.
+
+**PR-4 verification:** compile + full build; check that deprecated bridges keep the old signatures binary-compatible (japicmp if available via parent).
+
+---
+
+## Cluster 5 — Build, dependencies & CI (PR-5)
+
+Branch suggestion: `fix/build-dependencies-ci`.
+
+### BUILD-1 [M] Used-but-undeclared dependency `de.cuioss:cui-java-tools`
+- `pom.xml` dependencies block (lines 46-118) — ~40 `de.cuioss.tools.*` imports across ~15 main-source files (e.g. `JsfSetupExtension.java:23`) rely on a transitive edge via `cui-test-value-objects`/`cui-test-generator`.
+- **Fix:** declare `de.cuioss:cui-java-tools` explicitly (version/scope managed by `cui-java-bom`).
+
+### BUILD-2 [m] Unused declared dependency `jakarta.websocket:jakarta.websocket-api`
+- `pom.xml:60-63` — zero references in src. **Fix:** remove.
+
+### BUILD-3 [m] Unused declared dependency `jakarta.validation:jakarta.validation-api`
+- `pom.xml:64-67` — no `jakarta.validation` imports anywhere. **Fix:** remove.
+
+### BUILD-4 [m] Unused declared dependency `de.cuioss.test:cui-test-juli-logger`
+- `pom.xml:105-108` — no references; effective scope `test`, so it doesn't reach consumers either. **Fix:** remove, or give it explicit `compile` scope if consumers are meant to receive it (then document).
+
+### BUILD-5 [m] Used-but-undeclared `org.junit.platform:junit-platform-commons`
+- `JsfSetupExtension.java:27` imports `AnnotationSupport` via the transitive edge from `junit-jupiter-api`. **Fix:** declare explicitly (compile scope).
+
+### BUILD-6 [m] Dependabot does not cover GitHub Actions
+- `.github/dependabot.yml:7-16` — only `maven`; the five workflows pin `cuioss/cuioss-organization` reusable workflows to a fixed SHA with no update automation.
+- **Fix:** add a `package-ecosystem: "github-actions"` entry.
+
+### BUILD-7 [m] Duplicate CI runs for Dependabot PRs
+- `.github/workflows/maven.yml:5-9` — `push` on `dependabot/**` + `pull_request` on `main` → every Dependabot PR builds twice.
+- **Fix:** drop `"dependabot/**"` from the push list; optionally add a `concurrency` group.
+
+### BUILD-8 [m] Auto-merge workflow triggers on every PR
+- `.github/workflows/dependabot-auto-merge.yml:3-4` — bare `on: pull_request`, no actor guard at caller level.
+- **Fix:** add `if: github.actor == 'dependabot[bot]'` on the job.
+
+### BUILD-9 [m] Maven wrapper pins Maven 3.9.6 (Jan 2024)
+- `.mvn/wrapper/maven-wrapper.properties:19` — 3.9.x line is at ≥3.9.11. **Fix:** bump `distributionUrl`.
+
+### BUILD-10 [m] CLAUDE.md build metadata is stale (cross-ref DOC cluster)
+- `CLAUDE.md:307/310` — claims version 4.0-SNAPSHOT and parent 0.9.9.6; pom says 4.4-SNAPSHOT / `cui-java-parent:1.4.5`. Fixed together with DOC-3 in PR-7 (listed here for completeness — do not fix twice).
+
+**PR-5 verification:** `./mvnw dependency:analyze` clean(er); full build; CI on the PR itself proves the workflow edits.
+
+---
+
+## Cluster 6 — Test-suite quality & coverage (PR-6)
+
+Branch suggestion: `fix/test-quality-coverage`. Execute after PR-1/PR-2 so new tests cover fixed behavior.
+
+### TEST-1 [M] Untested main-source classes (aggregated)
+- No test references at all: `mocks/CuiMockHttpServletRequest`, `mocks/CuiMockHttpSession`, `mocks/CuiMockUIViewRoot`, `mocks/CuiMockConfigurableNavigationHandler` (own API untested), `util/JsfRuntimeSetup`, `util/ConfigurationHelper` (no dedicated test), `util/ConfigurableFacesTest` (zero coverage), `renderer/util/AttributeComparator`.
+- **Fix:** add contract tests, prioritizing the four unreferenced mocks — they are exactly where MOCK-2/4/6 lived undetected. PR-1/PR-2 regression tests cover part of this; fill the rest here.
+
+### TEST-2 [M] Resource-bundle test verifies the fallback, not a valid bundle
+- `src/test/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecoratorTest.java:41, 47-63`; orphaned resource `src/test/resources/de/icw/cui/test/jsf/testbundle.properties`
+- `BUNDLE_PATH = "de.cuioss.test.jsf.testbundle"` doesn't exist on the classpath (properties file still at the pre-rename `de/icw/...` path) and identity-bundle mode makes the "valid" and "invalid" branches exercise the same fallback — real bundle resolution is never verified.
+- **Fix:** move `testbundle.properties` to `src/test/resources/de/cuioss/test/jsf/`; assert real resolution under `@EnableJsfEnvironment(useIdentityResourceBundle = false)`.
+
+### TEST-3 [M] `JsfTestConfigurationAggregationTest` shared mutable static state
+- `src/test/java/de/cuioss/test/jsf/junit5/JsfTestConfigurationAggregationTest.java:48, 50-53, 61, 75, 89, 104`
+- Static `APPLIED_CONFIGS` cleared at the *end of each test body*; `clearAppliedConfigs()` is a pseudo-test existing only for cleanup. One assertion failure leaves stale state cascading into unrelated tests; unsafe under parallel execution.
+- **Fix:** clear in `@BeforeEach`/`@AfterEach`; delete the pseudo-test.
+- Note: this class is also the natural home for the LIFE-2 double-application regression test — its size assertions will change once LIFE-2 is fixed; coordinate.
+
+### TEST-4 [m] Empty override silently hides an inherited test
+- `src/test/java/de/cuioss/test/jsf/converter/AbstractSanitizingConverterTestTest.java:38-43`
+- `shouldSanitizeJavaScript` overridden with an empty body → reported green while asserting nothing.
+- **Fix:** annotate the override `@Disabled("replaced by shouldDetectInvalid/ValidEscaping")`.
+
+### TEST-5 [m] Never-reset static dispatch flags
+- `src/test/java/de/cuioss/test/jsf/util/JsfTestSetupDispatchTest.java:53-55` — `BareSetup.*Called` statics never reset; leaks as soon as the fixture is reused; not parallel-safe.
+- **Fix:** reset in `@BeforeEach`/`@AfterEach`.
+
+### TEST-6 [m] Test class name claims coverage it doesn't provide
+- `src/test/java/de/cuioss/test/jsf/util/ConfigurableFacesTestTest.java:45-47` — never touches `ConfigurableFacesTest`.
+- **Fix:** rename (e.g. `EnableJsfEnvironmentBasicConfigurationTest`) and add a real `ConfigurableFacesTest`-extending test (pairs with LIFE-3 and TEST-1).
+
+### TEST-7 [m] Contradictory assertion message
+- `src/test/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecoratorTest.java:111` — `assertNotNull(request.getCookies(), "Cookies should not be there")`; also redundant next to line 112.
+- **Fix:** drop the redundant assert or fix the message.
+
+### TEST-8 [m] Success-by-no-exception without assertion
+- `src/test/java/de/cuioss/test/jsf/junit5/BackwardCompatibilityTest.java:85-88` — two bare `registerCuiMockComponentWithRenderer()` calls; nothing asserts the registrations took effect.
+- **Fix:** assert e.g. `assertNotNull(application.createComponent(CuiMockComponent.COMPONENT_TYPE))`.
+
+**PR-6 verification:** full build; run suite twice; confirm new coverage via the `coverage` profile if desired.
+
+---
+
+## Cluster 7 — Documentation & Javadoc (PR-7)
+
+Branch suggestion: `fix/documentation`. Last, so docs describe post-fix behavior.
+
+### DOC-1 [C] `doc/usage.adoc` flagship renderer example uses a removed API
+- `doc/usage.adoc:284-402` (esp. 322-323, 334-335, 351-399) — built on `HtmlTreeBuilder`, `Node`, `AttributeName`, none of which exist anywhere (verified incl. dependency jars); also uses the 2-arg `assertRenderResult` while the real methods require a `FacesContext` third argument (`AbstractRendererTestBase.java:142,158`).
+- **Fix:** rewrite against the current API: `assertRenderResult(component, expectedHtmlString, facesContext)` / `DomUtils.htmlStringToDocument`. Also fix line 292: the example's `implements ComponentConfigurator` contradicts the same doc's deprecation note at lines 70-97 — use a `ComponentConfigDecorator` parameter.
+
+### DOC-2 [C] CLAUDE.md architecture + renderer example reference the same removed API
+- `CLAUDE.md:93, 218-226` — lists "`HtmlTreeBuilder`: Programmatic HTML tree construction" and shows the non-compiling 2-arg example. AI tooling treats this file as authoritative — generated tests won't compile.
+- **Fix:** remove `HtmlTreeBuilder` from the architecture list; rewrite the example with the real signature.
+
+### DOC-3 [C] CLAUDE.md documents a non-existent build profile and stale versions
+- `CLAUDE.md:28, 47-48` — all build commands use `-Prewrite`, but no `rewrite` profile exists in this pom or in parent `cui-java-parent:1.4.5` (the openrewrite execution lives in the `pre-commit` profile).
+- `CLAUDE.md:307, 310` — version 4.0-SNAPSHOT vs actual 4.4-SNAPSHOT; parent 0.9.9.6 vs actual 1.4.5.
+- **Fix:** replace `-Prewrite` with `-Ppre-commit`; update or drop hard-coded versions. (= BUILD-10.)
+
+### DOC-4 [M] Broken `doc/migration.adoc` references
+- `CLAUDE.md:296, 301` and `doc/usage.adoc:107, 187` — the file doesn't exist; actual files are `doc/migration/4.1.adoc` and `doc/migration/4.3.adoc` (README links them correctly).
+- **Fix:** point at the real files.
+
+### DOC-5 [M] Stale `javax.faces.*` strings in examples
+- `doc/migration/4.1.adoc:156, 170, 247` and `src/main/java/de/cuioss/test/jsf/config/ComponentConfigurator.java:33` — `registerMockRenderer("javax.faces.Output", "javax.faces.Text")` compiles but registers under a family no Jakarta component uses; following the example silently fails.
+- **Fix:** replace with `jakarta.faces.*`.
+
+### DOC-6 [m] "HTML tree generation" advertised though generation tooling was removed
+- `README.adoc:28`, `doc/usage.adoc:13`, `CLAUDE.md:7` — only the assertion side survives.
+- **Fix:** reword to "HTML-tree assertion tooling".
+
+### DOC-7 [m] Platform baseline internally inconsistent
+- `doc/usage.adoc:16`, `CLAUDE.md:7, 281` — "Jakarta EE 10 (JSF 4.1+)": Faces 4.1 (myfaces-api 4.1.2, actually used) belongs to EE 11; EE 10 ships Faces 4.0.
+- **Fix:** say "Jakarta Faces 4.1 (Jakarta EE 11)".
+
+### DOC-8 [m] References to removed class `JsfEnabledTestEnvironment` presented as existing
+- `CLAUDE.md:293` (listed as "deprecated" — it's removed) and `doc/migration/4.1.adoc:42, 89-96, 190`.
+- **Fix:** state it was removed in 4.x.
+
+### DOC-9 [m] Misspelled attribute reference `useIdentityResouceBundle`
+- `doc/usage.adoc:212` and `ConfigurableFacesTest.java:69` (Javadoc `#isUseIdentityResouceBundle()`).
+- **Fix:** correct spelling (`useIdentityResourceBundle`).
+
+### DOC-10 [m] CLAUDE.md misc inaccuracies
+- Line 107-108: `NavigationAsserts` listed under `util/` — it lives in `junit5/`. Line 309 vs README:36 — "v2 branch" vs actual `release/v2`.
+- **Fix:** correct both.
+
+### DOC-11 [m] `EnableJsfEnvironment` Javadoc steers users to deprecated patterns
+- `src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironment.java:45-48, 64-80` — "Complex Sample" showcases `implements JsfEnvironmentConsumer` (deprecated) without a note; configurator-interface scanning described as a primary mechanism.
+- **Fix:** replace the sample with parameter resolution; mark the legacy paragraph as deprecated.
+
+### DOC-12 [m] Copy-paste / contradictory Javadoc (aggregated)
+- `converter/TestItems.java:109-132` — `addValidObject*` documented as "should cause a ConverterException" (opposite); lines 242-257 — `addStringTestItem` param docs swap input/result meaning.
+- `validator/TestItems.java:60-69` — `addValid` documented as "must fail with ValidatorException".
+- `util/JsfEnvironmentHolder.java:61-64` — `getRequestConfigDecorator()` documented as returning an `ApplicationConfigDecorator`.
+- `util/JsfEnvironmentConsumer.java:70` — example calls non-existent `getBeanConfigDecorator()`.
+- `config/decorator/ApplicationConfigDecorator.java` class doc — enumeration ends mid-sentence; also lines 159-166: `setProjectStage` exception message claims an "underlying Exception" when the field simply wasn't found.
+- `config/decorator/ComponentConfigDecorator.java:64` — constant text "component must not be null" used for null `componentType` (line 175); lines 134-147 — `registerConverter(Class)` silently registers nothing when `@FacesConverter` has neither `value` nor a specific `forClass` — throw `IllegalArgumentException`.
+- `component/ValueExpressionPropertyContract.java:36, 60-62` — nonsense generic-param Javadoc and empty `@param` tags.
+- `junit5/AbstractPropertyAwareFacesTest.java:83-85` — claims `SortedSet`, returns `List`.
+- **Fix:** correct each in place.
+
+### DOC-13 [m] Missing `package-info.java`
+- Missing for public packages: `component`, `config`, `config/component`, `config/renderer`, `generator`, `mocks`, `producer`, `renderer`, `util`.
+- **Fix:** add package-info files (notably `mocks` and `renderer`).
+
+### DOC-14 [m] Getter visibility inconsistency in `ConfigurableFacesTest`
+- `ConfigurableFacesTest.java:83-88` — two decorators `PROTECTED`, `requestConfigDecorator` public.
+- **Fix:** align (protected).
+
+### DOC-15 [m] Verify `./mvnw -Pjavadoc clean install` passes after all Javadoc edits
+- CLAUDE.md's own cleanup command (adjusted per DOC-3 if the profile name differs).
+
+**PR-7 verification:** `./mvnw -Ppre-commit clean install` and the javadoc profile build; manual render check of the adoc files.
+
+---
+
+## Cluster 8 — Final verification & cleanup (PR-8)
+
+1. Re-read every finding ID above against the current `main` and mark it **fixed / consciously-skipped** (skips need a one-line justification recorded in the PR description).
+2. Run the complete verification suite: `./mvnw clean install`, `./mvnw -Ppre-commit clean install`, javadoc profile, `dependency:analyze`, suite run twice (ordering).
+3. Confirm the release-notes/migration entries for the behavior-changing fixes (MOCK-1, MOCK-2, MOCK-4, LIFE-2, LIFE-3) exist.
+4. **If — and only if — every finding is verified fixed or consciously skipped: delete `doc/review-26-07-04.md` in this PR.** If findings remain, keep the document, strike through completed items, and stop for user input.
+
+---
+
+## Per-PR workflow (applies to every PR above)
+
+All work happens on feature branches — `main` is branch-protected.
+
+1. `git checkout main && git pull` — always branch from fresh main.
+2. `git checkout -b <branch-name>` (suggested names per cluster above).
+3. Implement the cluster's fixes **including the regression tests named in the cluster**.
+4. Verify locally: `./mvnw clean install` (plus cluster-specific verification listed above).
+5. Commit with descriptive messages referencing the finding IDs (e.g. `fix(mocks): correct inverted libraryExists logic (MOCK-1)`).
+6. `git push -u origin <branch-name>` (retry up to 4× with exponential backoff on network errors only).
+7. Create the PR against `main`; the PR body lists the finding IDs addressed.
+8. Wait for CI + the Gemini review — `gh pr checks --watch`, then **wait ~5 minutes** for review comments to arrive.
+9. **Handle every review comment** (fetch via `gh api repos/cuioss/cui-jsf-test-basic/pulls/<pr>/comments`):
+   - Clearly valid & fixable → fix, commit, push, reply explaining the fix, resolve.
+   - Disagree / out of scope → reply explaining why, resolve.
+   - Uncertain → **stop and ask the user** before acting.
+   - Every comment gets a reply AND is resolved — no exceptions.
+10. Merge once CI is green and all comments are resolved (no auto-merge).
+11. `git checkout main && git pull`, then start the next cluster.
+
+If a Gemini/CI finding reveals a defect in *another* cluster's territory, do not fix it in the current
+PR — append it to this document under the owning cluster instead.


### PR DESCRIPTION
## Summary

Adds `doc/review-26-07-04.md` — the consolidated result of a full-project analysis (all main sources, tests, `pom.xml`, `.github/` workflows, and documentation). **This PR contains no code changes; it is the review document and fix plan only.** The actual fixes are follow-up work.

The document contains:

- **~70 findings** with severity, `file:line` references, defect statements, and concrete fix hints: 3 critical (documentation showcasing a removed `HtmlTreeBuilder` API), 13 major (e.g. inverted `CuiMockResourceHandler.libraryExists`, navigation mock reporting success for unregistered outcomes, `CuiMockHttpSession.invalidate()` never invalidating, nondeterministic/double application of `@JsfTestConfiguration`, missing teardown in `ConfigurableFacesTest`, undeclared `cui-java-tools` dependency), and ~55 minor items.
- **Partitioning into 8 PR clusters** (mock behavior, lifecycle/configuration, assertion robustness, public-API naming via deprecation path, build/CI, test quality, documentation, final verification) with a recommended execution order and dependency notes.
- **A per-PR workflow** (feature branch → CI + Gemini review → handle every comment → merge) and a **final verification step** that re-checks every finding and removes the review document once all findings are resolved.
- Explicit **behavior-change warnings** for fixes that alter observable mock behavior consumers may depend on.

## Verification

- Baseline build confirmed green before review: `./mvnw test` — 228 tests, 0 failures.
- Documentation-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SEaMJCbTuZvKgi6NXKvYR

---
_Generated by [Claude Code](https://claude.ai/code/session_013SEaMJCbTuZvKgi6NXKvYR)_