### PR TITLE
fix(mocks): correct mock-layer contract violations (MOCK-1…MOCK-14)

### DIFF
--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockConfigurableNavigationHandler.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockConfigurableNavigationHandler.java
@@ -37,6 +37,13 @@ public class CuiMockConfigurableNavigationHandler extends ConfigurableNavigation
 
     private static final CuiLogger LOGGER = new CuiLogger(CuiMockConfigurableNavigationHandler.class);
 
+    /**
+     * Registered navigation cases. Deviation from the JSF spec: whereas
+     * {@link ConfigurableNavigationHandler#getNavigationCases()} keys the map by
+     * from-view-id, this mock keys it by {@code "fromAction|outcome"} (see
+     * {@link #calculateKey(String, String)}) to match the way cases are registered
+     * for tests.
+     */
     @Getter
     private final Map<String, Set<NavigationCase>> navigationCases = new HashMap<>();
 
@@ -78,16 +85,19 @@ public class CuiMockConfigurableNavigationHandler extends ConfigurableNavigation
         }
         final var navigationCase = getNavigationCase(context, fromAction, outcome);
 
-        var newViewId = outcome;
-        try {
+        // JSF spec: with no matching navigation case the current view is retained.
+        // Do not redirect and do not set the tracking flags, so an unregistered
+        // outcome does not count as navigation.
+        if (null == navigationCase) {
+            return;
+        }
 
-            if (null == navigationCase) {
-                externalContext.redirect(outcome);
-            } else {
-                newViewId = navigationCase.getToViewId(context);
+        final var newViewId = navigationCase.getToViewId(context);
+        try {
+            // Only registered redirect cases commit a redirect response.
+            if (navigationCase.isRedirect()) {
                 externalContext.redirect(newViewId);
             }
-
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -124,10 +134,10 @@ public class CuiMockConfigurableNavigationHandler extends ConfigurableNavigation
 
         final var key = calculateKey(fromAction, outcome);
 
-        navigationCases.remove(key);
-
         navigationCases.put(key, new HashSet<>(List.of(navigationCase)));
-        addNavigationWithFromActionCalled = true;
+        if (null != fromAction) {
+            addNavigationWithFromActionCalled = true;
+        }
         return this;
     }
 

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockContextCallback.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockContextCallback.java
@@ -44,7 +44,7 @@ public class CuiMockContextCallback implements ContextCallback {
     }
 
     /**
-     * Checks whether callback has been called at least one time
+     * Checks whether callback has never been called
      */
     public void assertNotCalledAtAll() {
         assertEquals(0, called, "Has been called " + called + " times");

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequest.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequest.java
@@ -53,7 +53,12 @@ public class CuiMockHttpServletRequest extends MockHttpServletRequest {
     // API defined
     @Override
     public Enumeration getLocales() {
-        return new Vector<>(requestLocales).elements();
+        var locales = requestLocales;
+        if (null == locales || locales.isEmpty()) {
+            // Servlet spec: at least the server default locale must be returned.
+            locales = mutableList(Locale.getDefault());
+        }
+        return new Vector<>(locales).elements();
     }
 
     @Override
@@ -119,32 +124,55 @@ public class CuiMockHttpServletRequest extends MockHttpServletRequest {
 
     /**
      * getSession should never return an invalidated session.
+     * <p>
+     * Contract notes:
+     * <ul>
+     * <li>An existing but invalidated session is dropped; with {@code create == false}
+     * this method then returns {@code null} instead of silently creating a fresh one.</li>
+     * <li>A foreign (non-{@link CuiMockHttpSession}) session is preserved in the
+     * read-only ({@code create == false}) path so its attributes are not lost.</li>
+     * </ul>
      */
     @Override
     public HttpSession getSession(final boolean create) {
-        HttpSession session = null;
-        if (!create) {
-            session = super.getSession(false);
-            if (null == session) {
+        var session = super.getSession(false);
+
+        // An existing session may have been invalidated; detect and drop it.
+        if (null != session && isInvalidated(session)) {
+            super.setHttpSession(null);
+            session = null;
+        }
+
+        if (null == session) {
+            if (!create) {
                 return null;
             }
-        } else {
-            session = super.getSession(true);
+            return createCuiSession();
         }
+
+        // Ensure a CuiMockHttpSession is returned, but only when creation is allowed.
+        // In the read-only path the existing (possibly foreign) session is preserved.
+        if (create && !(session instanceof CuiMockHttpSession)) {
+            return createCuiSession();
+        }
+        return session;
+    }
+
+    private static boolean isInvalidated(final HttpSession session) {
         try {
-            session.getAttribute("test"); // test if the session was invalidated
+            session.getAttribute("test");
+            return false;
         } catch (IllegalStateException e) {
-            super.setHttpSession(null);
-            session = super.getSession(true);
+            return true;
         }
-        if (!(session instanceof CuiMockHttpSession)) {
-            session = new CuiMockHttpSession(getServletContext());
-            super.setHttpSession(session);
-            var container = getWebContainer();
-            if (container != null) {
-                var se = new HttpSessionEvent(session);
-                container.sessionCreated(se);
-            }
+    }
+
+    private HttpSession createCuiSession() {
+        HttpSession session = new CuiMockHttpSession(getServletContext());
+        super.setHttpSession(session);
+        var container = getWebContainer();
+        if (container != null) {
+            container.sessionCreated(new HttpSessionEvent(session));
         }
         return session;
     }

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequest.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequest.java
@@ -58,7 +58,7 @@ public class CuiMockHttpServletRequest extends MockHttpServletRequest {
             // Servlet spec: at least the server default locale must be returned.
             locales = mutableList(Locale.getDefault());
         }
-        return new Vector<>(locales).elements();
+        return Collections.enumeration(locales);
     }
 
     @Override
@@ -143,19 +143,16 @@ public class CuiMockHttpServletRequest extends MockHttpServletRequest {
             session = null;
         }
 
-        if (null == session) {
-            if (!create) {
-                return null;
-            }
-            return createCuiSession();
+        if (null != session) {
+            // Preserve the existing (possibly foreign) session so its attributes are
+            // never discarded, regardless of the create flag.
+            return session;
         }
 
-        // Ensure a CuiMockHttpSession is returned, but only when creation is allowed.
-        // In the read-only path the existing (possibly foreign) session is preserved.
-        if (create && !(session instanceof CuiMockHttpSession)) {
-            return createCuiSession();
+        if (!create) {
+            return null;
         }
-        return session;
+        return createCuiSession();
     }
 
     private static boolean isInvalidated(final HttpSession session) {

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpSession.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockHttpSession.java
@@ -20,9 +20,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.myfaces.test.mock.MockHttpSession;
 
-import java.util.Collection;
-import java.util.Collections;
-
 /**
  * Extension to {@link MockHttpSession} that provides the programmatic setting
  * of 'maxInactiveInterval'
@@ -44,11 +41,12 @@ public class CuiMockHttpSession extends MockHttpSession {
         super(servletContext);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void invalidate() {
-        Collection<String> names = Collections.list(super.getAttributeNames());
-        names.forEach(super::removeAttribute);
+        // Delegate to the base implementation which clears the attributes and, more
+        // importantly, sets the 'invalid' flag so subsequent get/setAttribute calls
+        // throw IllegalStateException as required by the servlet contract.
+        super.invalidate();
     }
 
 }

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockMethodExpression.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockMethodExpression.java
@@ -75,7 +75,8 @@ public class CuiMockMethodExpression extends MethodExpression {
     @Override
     public Object invoke(final ELContext context, final Object[] params) {
         invoked = true;
-        invokedParams = Arrays.copyOf(params, params.length);
+        // EL API allows params == null for zero-arg methods.
+        invokedParams = params == null ? new Object[0] : Arrays.copyOf(params, params.length);
         return invokeResult;
     }
 }

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockRenderer.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockRenderer.java
@@ -83,7 +83,9 @@ public class CuiMockRenderer extends Renderer {
             writeBasicAttributes(context, component);
 
             if (component instanceof EditableValueHolder valueHolder) {
-                context.getResponseWriter().writeAttribute(VALUE, valueHolder.getValue(), VALUE);
+                if (null != valueHolder.getValue()) {
+                    context.getResponseWriter().writeAttribute(VALUE, valueHolder.getValue(), VALUE);
+                }
             } else if (component instanceof UIOutcomeTarget) {
                 handleOutputTarget(context, component);
             } else if (component instanceof HtmlOutputLink) {

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandler.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandler.java
@@ -128,7 +128,7 @@ public class CuiMockResourceHandler extends ResourceHandler {
 
     @Override
     public boolean libraryExists(final String libraryName) {
-        return LIBRARY_NOT_THERE.equals(libraryName);
+        return !LIBRARY_NOT_THERE.equals(libraryName);
     }
 
     @Override
@@ -141,8 +141,20 @@ public class CuiMockResourceHandler extends ResourceHandler {
         return resourceRequest;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <em>Mock deviation:</em> whereas the specification returns {@code null} when no
+     * renderer type matches, this mock returns a deterministic synthetic value
+     * ({@code resourceName + }{@link #RENDERER_SUFFIX}) for every non-empty resource
+     * name so that tests can assert on a stable renderer type. {@code null} is only
+     * returned for a {@code null} or empty resource name.
+     */
     @Override
     public String getRendererTypeForResourceName(final String resourceName) {
+        if (MoreStrings.isEmpty(resourceName)) {
+            return null;
+        }
         return resourceName + RENDERER_SUFFIX;
     }
 }

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockSearchExpressionHandler.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockSearchExpressionHandler.java
@@ -94,7 +94,7 @@ public class CuiMockSearchExpressionHandler extends SearchExpressionHandler {
         }
         if (null != resolvedComponent) {
             callback.invokeContextCallback(searchExpressionContext.getFacesContext(), resolvedComponent);
-        } else if (shouldIgnoreNoResult(searchExpressionContext)) {
+        } else if (shouldFailOnNoResult(searchExpressionContext)) {
             throw new ComponentNotFoundException(UNABLE_TO_FIND_COMPONENT_WITH_EXPRESSION + expression);
         }
 
@@ -103,11 +103,11 @@ public class CuiMockSearchExpressionHandler extends SearchExpressionHandler {
     @Override
     public void resolveComponents(SearchExpressionContext searchExpressionContext, String expressions,
         ContextCallback callback) {
-        requireNonNull(resolvedComponents);
+        requireNonNull(resolvedComponents, "resolvedComponents must not be null");
         if (MoreStrings.isEmpty(expressions)) {
             throw new ComponentNotFoundException(UNABLE_TO_FIND_COMPONENT_WITH_EXPRESSION + expressions);
         }
-        if (resolvedComponents.isEmpty() && shouldIgnoreNoResult(searchExpressionContext)) {
+        if (resolvedComponents.isEmpty() && shouldFailOnNoResult(searchExpressionContext)) {
             throw new ComponentNotFoundException("Unable to find components with expression = " + expressions);
         }
 
@@ -115,7 +115,12 @@ public class CuiMockSearchExpressionHandler extends SearchExpressionHandler {
             component -> callback.invokeContextCallback(searchExpressionContext.getFacesContext(), component));
     }
 
-    private boolean shouldIgnoreNoResult(SearchExpressionContext searchExpressionContext) {
+    /**
+     * @return {@code true} if a missing result should raise a
+     * {@link ComponentNotFoundException}, i.e. when the hints do <em>not</em>
+     * request {@link SearchExpressionHint#IGNORE_NO_RESULT}.
+     */
+    private boolean shouldFailOnNoResult(SearchExpressionContext searchExpressionContext) {
         var expressionHints = searchExpressionContext.getExpressionHints();
         return null == expressionHints || !expressionHints.contains(SearchExpressionHint.IGNORE_NO_RESULT);
     }

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockSearchExpressionHandler.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockSearchExpressionHandler.java
@@ -103,6 +103,8 @@ public class CuiMockSearchExpressionHandler extends SearchExpressionHandler {
     @Override
     public void resolveComponents(SearchExpressionContext searchExpressionContext, String expressions,
         ContextCallback callback) {
+        requireNonNull(searchExpressionContext, "searchExpressionContext must not be null");
+        requireNonNull(callback, "callback must not be null");
         requireNonNull(resolvedComponents, "resolvedComponents must not be null");
         if (MoreStrings.isEmpty(expressions)) {
             throw new ComponentNotFoundException(UNABLE_TO_FIND_COMPONENT_WITH_EXPRESSION + expressions);

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockServletContext.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockServletContext.java
@@ -35,7 +35,7 @@ public class CuiMockServletContext extends MockServletContext {
     @Setter
     private String virtualServerName = "virtual";
     @Setter
-    private String contextPath = "mock-context";
+    private String contextPath = "/mock-context";
     @Setter
     private SessionCookieConfig sessionCookieConfig;
 

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockUIViewRoot.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockUIViewRoot.java
@@ -31,7 +31,7 @@ import static de.cuioss.tools.collect.CollectionLiterals.mutableMap;
 public class CuiMockUIViewRoot extends UIViewRoot {
 
     private final Map<String, UIComponent> componentMap = mutableMap();
-    private final Map<String, Object> viewMap = mutableMap();
+    private Map<String, Object> viewMap;
 
     /**
      * @param expr      must not be null
@@ -51,11 +51,14 @@ public class CuiMockUIViewRoot extends UIViewRoot {
 
     @Override
     public Map<String, Object> getViewMap() {
-        return viewMap;
+        return getViewMap(true);
     }
 
     @Override
     public Map<String, Object> getViewMap(boolean create) {
+        if (null == viewMap && create) {
+            viewMap = mutableMap();
+        }
         return viewMap;
     }
 }

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockViewHandler.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockViewHandler.java
@@ -72,7 +72,15 @@ public class CuiMockViewHandler extends MockViewHandler {
         }
 
         private static String key(String libraryName, String tagName) {
-            return libraryName + '|' + tagName;
+            // Composite-component namespaces are often full URIs (e.g.
+            // "http://xmlns.jcp.org/jsf/composite/myLib" or "jakarta.faces.composite/myLib").
+            // Normalize to the last path segment so a registration by short name still
+            // resolves when JSF looks it up via the full namespace URI.
+            var normalizedLibrary = libraryName;
+            if (normalizedLibrary != null && normalizedLibrary.contains("/")) {
+                normalizedLibrary = normalizedLibrary.substring(normalizedLibrary.lastIndexOf('/') + 1);
+            }
+            return normalizedLibrary + '|' + tagName;
         }
 
         @Override

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockViewHandler.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockViewHandler.java
@@ -15,28 +15,38 @@
  */
 package de.cuioss.test.jsf.mocks;
 
+import jakarta.faces.application.Resource;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
 import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.StateManagementStrategy;
 import jakarta.faces.view.ViewDeclarationLanguage;
+import jakarta.faces.view.ViewMetadata;
 import org.apache.myfaces.test.mock.MockViewHandler;
-import org.easymock.EasyMock;
+
+import java.beans.BeanInfo;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * In addition to {@link MockViewHandler} this extension provides a mocked
- * {@link #getViewDeclarationLanguage(FacesContext, String)} using
- * {@link EasyMock} and a method for dynamically adding Composite-Component:
- * {@link #registerCompositeComponent(String, String, UIComponent)} Technically
- * they have not other use but being defined.
+ * In addition to {@link MockViewHandler} this extension provides a
+ * {@link #getViewDeclarationLanguage(FacesContext, String)} backed by a small
+ * hand-written {@link ViewDeclarationLanguage} stub and a method for dynamically
+ * adding composite components:
+ * {@link #registerCompositeComponent(String, String, UIComponent)}. In contrast
+ * to a mock-library based implementation any number of composite components can
+ * be registered.
  *
  * @author Oliver Wolff
  */
 public class CuiMockViewHandler extends MockViewHandler {
 
-    final ViewDeclarationLanguage mock = EasyMock.niceMock(ViewDeclarationLanguage.class);
+    private final CompositeComponentViewDeclarationLanguage viewDeclarationLanguage =
+        new CompositeComponentViewDeclarationLanguage();
 
     @Override
     public ViewDeclarationLanguage getViewDeclarationLanguage(FacesContext context, String viewId) {
-        return mock;
+        return viewDeclarationLanguage;
     }
 
     /**
@@ -45,8 +55,70 @@ public class CuiMockViewHandler extends MockViewHandler {
      * @param uiComponent must not be null
      */
     public void registerCompositeComponent(String libraryName, String tagName, UIComponent uiComponent) {
-        EasyMock.expect(mock.createComponent(EasyMock.anyObject(), EasyMock.eq(libraryName), EasyMock.eq(tagName),
-            EasyMock.anyObject())).andReturn(uiComponent).anyTimes();
-        EasyMock.replay(mock);
+        viewDeclarationLanguage.register(libraryName, tagName, uiComponent);
+    }
+
+    /**
+     * Minimal {@link ViewDeclarationLanguage} that resolves composite components
+     * from an internal map keyed by {@code libraryName + '|' + tagName}. All other
+     * operations are unsupported as they are not needed within the test-context.
+     */
+    private static final class CompositeComponentViewDeclarationLanguage extends ViewDeclarationLanguage {
+
+        private final Map<String, UIComponent> composites = new HashMap<>();
+
+        void register(String libraryName, String tagName, UIComponent uiComponent) {
+            composites.put(key(libraryName, tagName), uiComponent);
+        }
+
+        private static String key(String libraryName, String tagName) {
+            return libraryName + '|' + tagName;
+        }
+
+        @Override
+        public UIComponent createComponent(FacesContext context, String taglibURI, String tagName,
+            Map<String, Object> attributes) {
+            return composites.get(key(taglibURI, tagName));
+        }
+
+        @Override
+        public void buildView(FacesContext context, UIViewRoot root) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UIViewRoot createView(FacesContext context, String viewId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BeanInfo getComponentMetadata(FacesContext context, Resource componentResource) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Resource getScriptComponentResource(FacesContext context, Resource componentResource) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public StateManagementStrategy getStateManagementStrategy(FacesContext context, String viewId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ViewMetadata getViewMetadata(FacesContext context, String viewId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void renderView(FacesContext context, UIViewRoot view) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UIViewRoot restoreView(FacesContext context, String viewId) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/src/main/java/de/cuioss/test/jsf/mocks/ReverseConverter.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/ReverseConverter.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.test.jsf.mocks;
 
+import de.cuioss.tools.string.MoreStrings;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.convert.Converter;
@@ -39,20 +40,27 @@ public class ReverseConverter implements Converter<String> {
 
     @Override
     public String getAsObject(final FacesContext context, final UIComponent component, final String value) {
-        return reverse(context, component, value);
+        requireNonNull(component);
+        requireNonNull(context);
+        // Converter contract: return null for null/empty input.
+        if (MoreStrings.isEmpty(value)) {
+            return null;
+        }
+        return reverse(value);
     }
 
     @Override
     public String getAsString(final FacesContext context, final UIComponent component, final String value) {
-        return reverse(context, component, value);
-    }
-
-    private String reverse(final FacesContext context, final UIComponent component, final String value) {
         requireNonNull(component);
         requireNonNull(context);
+        // Converter contract: return a zero-length String for a null value.
         if (null == value) {
             return "";
         }
+        return reverse(value);
+    }
+
+    private static String reverse(final String value) {
         return new StringBuilder(value).reverse().toString();
     }
 

--- a/src/test/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecoratorTest.java
+++ b/src/test/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecoratorTest.java
@@ -84,7 +84,12 @@ class RequestConfigDecoratorTest {
 
         decorator.setRequestLocale();
         assertNull(externalContext.getRequestLocale());
-        assertFalse(externalContext.getRequestLocales().hasNext());
+        // MOCK-7: getLocales must never return an empty enumeration; it falls back to
+        // the server default locale as required by the servlet specification.
+        var fallbackLocales = externalContext.getRequestLocales();
+        assertTrue(fallbackLocales.hasNext(),
+            "getRequestLocales must fall back to the default locale instead of being empty");
+        assertEquals(Locale.getDefault(), fallbackLocales.next());
 
         decorator.setRequestLocale(Locale.GERMAN, Locale.ENGLISH);
         assertEquals(Locale.GERMAN, externalContext.getRequestLocale());

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockConfigurableNavigationHandlerTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockConfigurableNavigationHandlerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.mocks;
+
+import de.cuioss.test.jsf.junit5.EnableJsfEnvironment;
+import jakarta.faces.application.NavigationCase;
+import jakarta.faces.context.FacesContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnableJsfEnvironment
+@DisplayName("CuiMockConfigurableNavigationHandler")
+class CuiMockConfigurableNavigationHandlerTest {
+
+    private static final String KNOWN_OUTCOME = "known";
+
+    @Test
+    @DisplayName("An unknown outcome must not count as navigation (MOCK-2)")
+    void unknownOutcomeIsNoNavigation(FacesContext facesContext) {
+        var handler = new CuiMockConfigurableNavigationHandler();
+
+        handler.handleNavigation(facesContext, null, "does-not-exist");
+
+        assertFalse(handler.isHandleNavigationCalled(),
+            "An unregistered outcome must not be reported as a handled navigation");
+        assertNull(handler.getCalledOutcome(), "No outcome should be recorded for an unknown navigation");
+        assertFalse(facesContext.getExternalContext().isResponseCommitted(),
+            "An unknown outcome must not commit a redirect response");
+    }
+
+    @Test
+    @DisplayName("A registered redirect case navigates and redirects (MOCK-3)")
+    void registeredRedirectCaseNavigates(FacesContext facesContext) {
+        var handler = new CuiMockConfigurableNavigationHandler();
+        handler.addNavigationCase(KNOWN_OUTCOME, redirectCase("/target.xhtml"));
+
+        handler.handleNavigation(facesContext, null, KNOWN_OUTCOME);
+
+        assertTrue(handler.isHandleNavigationCalled(), "A registered case must be reported as handled");
+        assertEquals(KNOWN_OUTCOME, handler.getCalledOutcome(), "The outcome must be recorded");
+        assertTrue(facesContext.getExternalContext().isResponseCommitted(),
+            "A registered redirect case must commit a redirect response");
+    }
+
+    @Test
+    @DisplayName("A non-redirect case updates the view without redirecting (MOCK-3)")
+    void nonRedirectCaseDoesNotRedirect(FacesContext facesContext) {
+        var handler = new CuiMockConfigurableNavigationHandler();
+        handler.addNavigationCase(KNOWN_OUTCOME, nonRedirectCase("/target.xhtml"));
+
+        handler.handleNavigation(facesContext, null, KNOWN_OUTCOME);
+
+        assertTrue(handler.isHandleNavigationCalled(), "A registered case must be reported as handled");
+        assertFalse(facesContext.getExternalContext().isResponseCommitted(),
+            "A non-redirect case must not commit a redirect response");
+    }
+
+    private static NavigationCase redirectCase(String toViewId) {
+        return new NavigationCase(null, null, KNOWN_OUTCOME, null, toViewId, null, null, true, true);
+    }
+
+    private static NavigationCase nonRedirectCase(String toViewId) {
+        return new NavigationCase(null, null, KNOWN_OUTCOME, null, toViewId, null, null, false, false);
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockConfigurableNavigationHandlerTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockConfigurableNavigationHandlerTest.java
@@ -70,6 +70,20 @@ class CuiMockConfigurableNavigationHandlerTest {
             "A non-redirect case must not commit a redirect response");
     }
 
+    @Test
+    @DisplayName("Registering with a fromAction sets the fromAction tracking flag (MOCK-14)")
+    void fromActionFlagSetOnlyWithFromAction() {
+        var handler = new CuiMockConfigurableNavigationHandler();
+
+        handler.addNavigationCase(KNOWN_OUTCOME, redirectCase("/target.xhtml"));
+        assertFalse(handler.isAddNavigationWithFromActionCalled(),
+            "The fromAction flag must not be set for the outcome-only overload");
+
+        handler.addNavigationCase("fromAction", KNOWN_OUTCOME, redirectCase("/target.xhtml"));
+        assertTrue(handler.isAddNavigationWithFromActionCalled(),
+            "The fromAction flag must be set when a fromAction is supplied");
+    }
+
     private static NavigationCase redirectCase(String toViewId) {
         return new NavigationCase(null, null, KNOWN_OUTCOME, null, toViewId, null, null, true, true);
     }

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequestTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockHttpServletRequestTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.mocks;
+
+import org.apache.myfaces.test.mock.MockHttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("CuiMockHttpServletRequest")
+class CuiMockHttpServletRequestTest {
+
+    private CuiMockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = new CuiMockHttpServletRequest();
+        request.setServletContext(new CuiMockServletContext());
+    }
+
+    @Test
+    @DisplayName("getSession(false) returns null when no session exists (MOCK-6)")
+    void shouldReturnNullForReadOnlyWithoutSession() {
+        assertNull(request.getSession(false), "No session must exist yet");
+    }
+
+    @Test
+    @DisplayName("getSession(true) creates a CuiMockHttpSession and returns it consistently")
+    void shouldCreateCuiSession() {
+        var session = request.getSession(true);
+        assertNotNull(session, "A session must be created");
+        assertInstanceOf(CuiMockHttpSession.class, session, "The created session must be a CuiMockHttpSession");
+        assertSame(session, request.getSession(false), "The same session must be returned afterwards");
+    }
+
+    @Test
+    @DisplayName("An invalidated session is dropped in the read-only path (MOCK-6)")
+    void shouldDropInvalidatedSession() {
+        var session = request.getSession(true);
+        session.invalidate();
+        assertNull(request.getSession(false), "An invalidated session must not be returned");
+    }
+
+    @Test
+    @DisplayName("A foreign session is preserved instead of being replaced (MOCK-6)")
+    void shouldPreserveForeignSession() {
+        var foreign = new MockHttpSession(new CuiMockServletContext());
+        request.setHttpSession(foreign);
+        assertSame(foreign, request.getSession(false), "A foreign session must be preserved");
+        assertSame(foreign, request.getSession(true), "A foreign session must not be replaced on create");
+    }
+
+    @Test
+    @DisplayName("getLocales falls back to the default locale when none configured (MOCK-7)")
+    void shouldFallBackToDefaultLocale() {
+        request.setRequestLocales(List.of());
+        var locales = request.getLocales();
+        assertTrue(locales.hasMoreElements(), "getLocales must not be empty");
+        assertEquals(Locale.getDefault(), locales.nextElement(), "Falls back to the server default locale");
+    }
+
+    @Test
+    @DisplayName("getLocales returns the configured locales when present")
+    void shouldReturnConfiguredLocales() {
+        request.setRequestLocales(List.of(Locale.GERMAN, Locale.ENGLISH));
+        var locales = request.getLocales();
+        assertEquals(Locale.GERMAN, locales.nextElement());
+        assertEquals(Locale.ENGLISH, locales.nextElement());
+        assertFalse(locales.hasMoreElements());
+    }
+
+    @Test
+    @DisplayName("getLocales falls back to the default locale when the list is null (MOCK-7)")
+    void shouldFallBackWhenLocalesNull() {
+        request.setRequestLocales(null);
+        var locales = request.getLocales();
+        assertTrue(locales.hasMoreElements(), "getLocales must not be empty for a null list");
+        assertEquals(Locale.getDefault(), locales.nextElement());
+    }
+
+    @Test
+    @DisplayName("getRequestURL reflects the configured request URL")
+    void shouldExposeRequestUrl() {
+        assertEquals(CuiMockHttpServletRequest.SERVLET_REQUEST_URL, request.getRequestURL().toString());
+        request.setRequestUrl("http://example.com/foo");
+        assertEquals("http://example.com/foo", request.getRequestURL().toString());
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockHttpSessionTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockHttpSessionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.mocks;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("CuiMockHttpSession")
+class CuiMockHttpSessionTest {
+
+    @Test
+    @DisplayName("invalidate should really invalidate the session (MOCK-4)")
+    void shouldInvalidateSession() {
+        var session = new CuiMockHttpSession(new CuiMockServletContext());
+        session.setAttribute("key", "value");
+        assertEquals("value", session.getAttribute("key"), "Attribute should be readable before invalidation");
+
+        session.invalidate();
+
+        assertThrows(IllegalStateException.class, () -> session.getAttribute("key"),
+            "Accessing an attribute on an invalidated session must throw IllegalStateException");
+        assertThrows(IllegalStateException.class, () -> session.setAttribute("key", "other"),
+            "Setting an attribute on an invalidated session must throw IllegalStateException");
+    }
+
+    @Test
+    @DisplayName("maxInactiveInterval should be settable programmatically")
+    void shouldSetMaxInactiveInterval() {
+        var session = new CuiMockHttpSession(new CuiMockServletContext());
+        session.setMaxInactiveInterval(42);
+        assertEquals(42, session.getMaxInactiveInterval(), "maxInactiveInterval should be configurable");
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockMethodExpressionTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockMethodExpressionTest.java
@@ -19,9 +19,32 @@ import de.cuioss.test.valueobjects.ValueObjectTest;
 import de.cuioss.test.valueobjects.api.contracts.VerifyBeanProperty;
 import de.cuioss.test.valueobjects.api.object.ObjectTestContracts;
 import de.cuioss.test.valueobjects.api.object.VetoObjectTestContract;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @VerifyBeanProperty(exclude = {"invokedParams", "parmetersProvided"})
 @VetoObjectTestContract(ObjectTestContracts.SERIALIZABLE)
 class CuiMockMethodExpressionTest extends ValueObjectTest<CuiMockMethodExpression> {
 
+    @Test
+    void shouldTrackInvocationWithParams() {
+        var expression = new CuiMockMethodExpression();
+        expression.setInvokeResult("result");
+
+        assertEquals("result", expression.invoke(null, new Object[]{"a", "b"}));
+        assertTrue(expression.isInvoked(), "invoke must mark the expression as invoked");
+        assertArrayEquals(new Object[]{"a", "b"}, expression.getInvokedParams(),
+            "invoke must record the passed parameters");
+    }
+
+    @Test
+    void shouldTolerateNullParams() {
+        var expression = new CuiMockMethodExpression();
+
+        assertNull(expression.invoke(null, null), "invoke returns the (unset) result");
+        assertTrue(expression.isInvoked(), "invoke must mark the expression as invoked");
+        assertEquals(0, expression.getInvokedParams().length,
+            "null params must be normalized to an empty array (MOCK-10)");
+    }
 }

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandlerTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandlerTest.java
@@ -18,7 +18,7 @@ package de.cuioss.test.jsf.mocks;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("CuiMockResourceHandler")
 class CuiMockResourceHandlerTest {
@@ -37,6 +37,31 @@ class CuiMockResourceHandlerTest {
         var key = CuiMockResourceHandler.createResourceMapKey("", "");
 
         assertEquals("notThere-notThere", key, "Blank input should map to the default placeholder");
+    }
+
+    @Test
+    @DisplayName("libraryExists should be true for real libraries and false only for the sentinel (MOCK-1)")
+    void shouldReportLibraryExistence() {
+        var handler = new CuiMockResourceHandler();
+
+        assertTrue(handler.libraryExists("some.real.library"),
+            "A real library must be reported as existing");
+        assertFalse(handler.libraryExists(CuiMockResourceHandler.LIBRARY_NOT_THERE),
+            "The sentinel library must be reported as not existing");
+    }
+
+    @Test
+    @DisplayName("getRendererTypeForResourceName returns null for empty input (MOCK-12)")
+    void shouldReturnNullRendererTypeForEmptyResourceName() {
+        var handler = new CuiMockResourceHandler();
+
+        assertNull(handler.getRendererTypeForResourceName(null),
+            "null resource name must not resolve to a renderer type");
+        assertNull(handler.getRendererTypeForResourceName(""),
+            "empty resource name must not resolve to a renderer type");
+        assertEquals("some.js" + CuiMockResourceHandler.RENDERER_SUFFIX,
+            handler.getRendererTypeForResourceName("some.js"),
+            "non-empty resource name resolves to the synthetic renderer type");
     }
 
 }

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockServletContextTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockServletContextTest.java
@@ -38,8 +38,8 @@ class CuiMockServletContextTest {
             () -> assertEquals(200, context.getSessionTimeout(), "Session timeout should default to 200"),
             () -> assertEquals("virtual", context.getVirtualServerName(),
                 "Virtual server name should default to 'virtual'"),
-            () -> assertEquals("mock-context", context.getContextPath(),
-                "Context path should default to 'mock-context'"),
+            () -> assertEquals("/mock-context", context.getContextPath(),
+                "Context path should default to '/mock-context'"),
             () -> assertNull(context.getSessionCookieConfig(), "Session cookie config should be null"));
     }
 

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockUIViewRootTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockUIViewRootTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.mocks;
+
+import jakarta.faces.component.html.HtmlInputText;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("CuiMockUIViewRoot")
+class CuiMockUIViewRootTest {
+
+    @Test
+    @DisplayName("getViewMap(false) returns null until the map is created (MOCK-8)")
+    void shouldNotCreateViewMapOnDemand() {
+        var root = new CuiMockUIViewRoot();
+
+        assertNull(root.getViewMap(false), "View map must be null until explicitly created");
+
+        var created = root.getViewMap(true);
+        assertNotNull(created, "getViewMap(true) must create the map");
+        assertSame(created, root.getViewMap(false), "The created map must be returned afterwards");
+        assertSame(created, root.getViewMap(), "The no-arg getViewMap must return the created map");
+    }
+
+    @Test
+    @DisplayName("addUiComponent registers a component resolvable via findComponent")
+    void shouldResolveRegisteredComponent() {
+        var root = new CuiMockUIViewRoot();
+        var component = new HtmlInputText();
+
+        root.addUiComponent("expr", component);
+
+        assertSame(component, root.findComponent("expr"), "Registered component must be resolvable");
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockViewHandlerTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockViewHandlerTest.java
@@ -65,4 +65,31 @@ class CuiMockViewHandlerTest {
             "Unknown composite component must resolve to null");
     }
 
+    @Test
+    @DisplayName("Should resolve a composite registered by short name via its full namespace URI (MOCK-5)")
+    void shouldNormalizeLibraryNamespace() {
+        var handler = new CuiMockViewHandler();
+        UIComponent component = new HtmlInputText();
+        handler.registerCompositeComponent("myLib", "tag", component);
+
+        var vdl = handler.getViewDeclarationLanguage(null, null);
+        assertSame(component, vdl.createComponent(null, "http://xmlns.jcp.org/jsf/composite/myLib", "tag", null),
+            "A full namespace URI must resolve to the short-name registration");
+    }
+
+    @Test
+    @DisplayName("The view declaration language stub rejects unsupported operations")
+    void shouldRejectUnsupportedVdlOperations() {
+        var vdl = new CuiMockViewHandler().getViewDeclarationLanguage(null, null);
+
+        assertThrows(UnsupportedOperationException.class, () -> vdl.buildView(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> vdl.createView(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> vdl.getComponentMetadata(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> vdl.getScriptComponentResource(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> vdl.getStateManagementStrategy(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> vdl.getViewMetadata(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> vdl.renderView(null, null));
+        assertThrows(UnsupportedOperationException.class, () -> vdl.restoreView(null, null));
+    }
+
 }

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockViewHandlerTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockViewHandlerTest.java
@@ -15,11 +15,13 @@
  */
 package de.cuioss.test.jsf.mocks;
 
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.html.HtmlInputText;
+import jakarta.faces.component.html.HtmlOutputText;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("CuiMockViewHandler")
 class CuiMockViewHandlerTest {
@@ -40,6 +42,27 @@ class CuiMockViewHandlerTest {
 
         assertDoesNotThrow(() -> handler.registerCompositeComponent(null, null, null),
             "Registering a composite component should not throw");
+    }
+
+    @Test
+    @DisplayName("Should support registering more than one composite component (MOCK-5)")
+    void shouldRegisterMultipleCompositeComponents() {
+        var handler = new CuiMockViewHandler();
+        UIComponent first = new HtmlInputText();
+        UIComponent second = new HtmlOutputText();
+
+        handler.registerCompositeComponent("libA", "tagA", first);
+        // A second registration on the same handler must not throw (regression for MOCK-5)
+        assertDoesNotThrow(() -> handler.registerCompositeComponent("libB", "tagB", second),
+            "Registering a second composite component must be supported");
+
+        var vdl = handler.getViewDeclarationLanguage(null, null);
+        assertSame(first, vdl.createComponent(null, "libA", "tagA", null),
+            "First composite component must be resolvable");
+        assertSame(second, vdl.createComponent(null, "libB", "tagB", null),
+            "Second composite component must be resolvable");
+        assertNull(vdl.createComponent(null, "libX", "tagX", null),
+            "Unknown composite component must resolve to null");
     }
 
 }

--- a/src/test/java/de/cuioss/test/jsf/mocks/ReverseConverterTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/ReverseConverterTest.java
@@ -17,11 +17,29 @@ package de.cuioss.test.jsf.mocks;
 
 import de.cuioss.test.jsf.converter.AbstractConverterTest;
 import de.cuioss.test.jsf.converter.TestItems;
+import jakarta.faces.component.html.HtmlInputText;
+import jakarta.faces.context.FacesContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ReverseConverterTest extends AbstractConverterTest<ReverseConverter, String> {
 
     @Override
     public void populate(TestItems<String> testItems) {
         testItems.addRoundtripValues("123");
+    }
+
+    @Test
+    void getAsObjectShouldReturnNullForNullOrEmptyInput(FacesContext facesContext) {
+        var converter = new ReverseConverter();
+        var component = new HtmlInputText();
+
+        // MOCK-9: getAsObject must return null for null/empty input
+        assertNull(converter.getAsObject(facesContext, component, null), "null input must convert to null");
+        assertNull(converter.getAsObject(facesContext, component, ""), "empty input must convert to null");
+        assertEquals("cba", converter.getAsObject(facesContext, component, "abc"),
+            "non-empty input must be reversed");
     }
 }


### PR DESCRIPTION
## Cluster 1 — Mock behavior correctness (PR-1)

Fixes spec/contract violations in the mock layer — the core product of this library — as identified in `doc/review-26-07-04.md`.

### Findings addressed
| ID | Fix |
|----|-----|
| MOCK-1 [M] | `CuiMockResourceHandler.libraryExists` logic was inverted → `!LIBRARY_NOT_THERE.equals(...)` |
| MOCK-2 [M] | Unknown navigation outcomes no longer report success / commit a redirect |
| MOCK-3 [m] | Redirect only performed when `navigationCase.isRedirect()` |
| MOCK-4 [M] | `CuiMockHttpSession.invalidate()` delegates to `super` (sets invalid flag, fires `sessionDestroyed`) |
| MOCK-5 [M] | `CuiMockViewHandler` uses a hand-written `ViewDeclarationLanguage` stub → supports multiple composite components |
| MOCK-6 [m] | `getSession(false)` returns `null` for invalidated sessions; preserves foreign sessions |
| MOCK-7 [m] | `getLocales()` falls back to the default locale (never empty) |
| MOCK-8 [m] | `getViewMap(false)` returns `null` until a map is created |
| MOCK-9 [m] | `ReverseConverter.getAsObject` returns `null` for null/empty input |
| MOCK-10 [m] | `CuiMockMethodExpression.invoke` tolerates `null` params |
| MOCK-11 [m] | `CuiMockRenderer` guards `EditableValueHolder` value against null |
| MOCK-12 [m] | `getRendererTypeForResourceName` returns `null` for empty input; deviation documented |
| MOCK-13 [m] | Renamed `shouldIgnoreNoResult` → `shouldFailOnNoResult`; added null-check message |
| MOCK-14 [m] | `contextPath` leading slash, `fromAction` tracking flag, Javadoc/typo fixes, removed redundant remove |

### Tests
New regression tests for MOCK-1, MOCK-2, MOCK-3, MOCK-4, MOCK-5, MOCK-12; `RequestConfigDecoratorTest` updated for the MOCK-7 locale fallback. Full `./mvnw clean install` green (236 tests).

### ⚠️ Behavior-change note (for release notes / migration)
MOCK-1, MOCK-2, MOCK-4 change observable behavior downstream consumers may depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y95DNbN4fZHSdaR4wAckzN)_