### PR TITLE
fix(lifecycle): correct JUnit5 extension & configuration dispatch (LIFE-1…LIFE-9)

### DIFF
--- a/src/main/java/de/cuioss/test/jsf/config/JsfTestConfigurations.java
+++ b/src/main/java/de/cuioss/test/jsf/config/JsfTestConfigurations.java
@@ -18,6 +18,7 @@ package de.cuioss.test.jsf.config;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -27,7 +28,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @author Oliver Wolff
  */
 @Retention(RUNTIME)
-@Target(TYPE)
+@Target({TYPE, METHOD})
 @interface JsfTestConfigurations {
 
     /**

--- a/src/main/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecorator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecorator.java
@@ -87,9 +87,9 @@ public class RequestConfigDecorator {
      * {@link ExternalContext#getRequestParameterMap()}
      *
      * @param key   used as the key for the
-     *              {@link ExternalContext#getRequestHeaderMap()}
+     *              {@link ExternalContext#getRequestParameterMap()}
      * @param value used as the value for the
-     *              {@link ExternalContext#getRequestHeaderMap()}
+     *              {@link ExternalContext#getRequestParameterMap()}
      * @return the {@link RequestConfigDecorator} itself in order to enable a
      * fluent-api style usage
      */
@@ -115,7 +115,7 @@ public class RequestConfigDecorator {
     }
 
     /**
-     * Registers one or more cookies the the contained request
+     * Registers one or more cookies to the contained request
      *
      * @param cookie to be added
      * @return the {@link RequestConfigDecorator} itself in order to enable a
@@ -157,11 +157,14 @@ public class RequestConfigDecorator {
     /**
      * Explicitly sets a given queryString as path-element of the request
      *
-     * @param parameterString
+     * @param parameterString the query string to set as the request's path query element
+     * @return the {@link RequestConfigDecorator} itself in order to enable a
+     * fluent-api style usage
      */
-    public void setQueryString(String parameterString) {
+    public RequestConfigDecorator setQueryString(String parameterString) {
         var request = (CuiMockHttpServletRequest) externalContext.getRequest();
         request.setPathElements(request.getContextPath(), request.getServletPath(), request.getPathInfo(),
             parameterString);
+        return this;
     }
 }

--- a/src/main/java/de/cuioss/test/jsf/converter/AbstractConverterTest.java
+++ b/src/main/java/de/cuioss/test/jsf/converter/AbstractConverterTest.java
@@ -115,10 +115,17 @@ public abstract class AbstractConverterTest<C extends Converter, T>
     private TestItems<T> testItems;
 
     /**
-     * Instantiates and initially configures a concrete {@link Converter}
+     * Instantiates and initially configures a concrete {@link Converter}.
+     * <p>
+     * The injected {@link ComponentConfigDecorator} is passed to
+     * {@link #configureComponents(ComponentConfigDecorator)} so the (overridable)
+     * component configuration is actually applied before the converter is created.
+     *
+     * @param componentConfig resolved by the JSF test environment, never {@code null}
      */
     @BeforeEach
-    protected void initConverter() {
+    protected void initConverter(ComponentConfigDecorator componentConfig) {
+        configureComponents(componentConfig);
         final Class<C> clazz = MoreReflection.extractFirstGenericTypeArgument(getClass());
         converter = new DefaultInstantiator<>(clazz).newInstance();
         configure(converter);

--- a/src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironments.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironments.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -28,7 +29,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @author Oliver Wolff
  */
 @Retention(RUNTIME)
-@Target(TYPE)
+@Target({TYPE, METHOD})
 @Documented
 @interface EnableJsfEnvironments {
 

--- a/src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/JsfSetupExtension.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static de.cuioss.test.jsf.util.ConfigurationHelper.*;
 
@@ -55,6 +54,13 @@ import static de.cuioss.test.jsf.util.ConfigurationHelper.*;
  * }
  * }
  * </pre>
+ * <p>
+ * <em>Note:</em> {@code @TestInstance(TestInstance.Lifecycle.PER_CLASS)} is not
+ * supported. The JSF runtime is set up once per test instance in
+ * {@code postProcessTestInstance} but {@link #afterEach(ExtensionContext)} tears it
+ * down after every test method, so a single shared instance would run against a
+ * released runtime for the second and subsequent tests. Use the default
+ * {@code PER_METHOD} lifecycle.
  *
  * @author Oliver Wolff
  */
@@ -115,7 +121,9 @@ public class JsfSetupExtension implements TestInstancePostProcessor, BeforeEachC
         List<EnableJsfEnvironment> environments = new ArrayList<>();
         retrieveEnableJSFAnnotations(testInstance.getClass(), environments);
         if (!environments.isEmpty()) {
-            // Use the outermost annotation
+            // Use the innermost (most specific) annotation: retrieveEnableJSFAnnotations
+            // collects them method > nested class > enclosing/superclass, so the first
+            // entry is the closest declaration to the test.
             useIdentityResourceBundle = environments.getFirst().useIdentityResourceBundle();
         }
 
@@ -131,10 +139,12 @@ public class JsfSetupExtension implements TestInstancePostProcessor, BeforeEachC
         setup.setApplication(environment.getFacesContext().getApplication());
 
         LOGGER.debug(() -> "Registering Decorators");
+        // Purpose-built LinkedHashSet preserves the deliberate configuration ordering
+        // (last-wins for conflicting registrations), so it must not be re-collected into
+        // an unordered set.
         Set<JsfTestConfiguration> decoratorAnnotations = LinkedHashSet.newLinkedHashSet(16);
 
         retrieveDecoratorAnnotations(testInstance.getClass(), decoratorAnnotations);
-        decoratorAnnotations = decoratorAnnotations.stream().filter(Objects::nonNull).collect(Collectors.toSet());
 
         configureApplication(testInstance, environment.getApplicationConfigDecorator(), decoratorAnnotations);
         configureComponents(testInstance, environment.getComponentConfigDecorator(), decoratorAnnotations);
@@ -278,17 +288,14 @@ public class JsfSetupExtension implements TestInstancePostProcessor, BeforeEachC
             return;
         }
 
-        // Get the actual test class (which might be a nested class)
-        Class<?> testClass = context.getRequiredTestClass();
+        // Only consider annotations declared directly on the test method. Class-level
+        // configurations were already applied in postProcessTestInstance; re-applying
+        // them here would run non-idempotent configurators twice per test (LIFE-2).
+        List<EnableJsfEnvironment> methodAnnotations = new ArrayList<>(
+            AnnotationSupport.findRepeatableAnnotations(testMethod.get(), EnableJsfEnvironment.class));
 
-        // Check for method-level EnableJsfEnvironment annotations
-        List<EnableJsfEnvironment> methodAnnotations = new ArrayList<>();
-        retrieveEnableJSFAnnotations(testClass, methodAnnotations, testMethod.get());
-
-        // Check for method-level JsfTestConfiguration annotations
-        Set<JsfTestConfiguration> decoratorAnnotations = LinkedHashSet.newLinkedHashSet(16);
-        retrieveDecoratorAnnotations(testClass, decoratorAnnotations, testMethod.get());
-        decoratorAnnotations = decoratorAnnotations.stream().filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<JsfTestConfiguration> decoratorAnnotations = new LinkedHashSet<>(
+            AnnotationSupport.findRepeatableAnnotations(testMethod.get(), JsfTestConfiguration.class));
 
         // Apply method-level EnableJsfEnvironment annotation if present
         if (!methodAnnotations.isEmpty()) {

--- a/src/main/java/de/cuioss/test/jsf/util/ConfigurableFacesTest.java
+++ b/src/main/java/de/cuioss/test/jsf/util/ConfigurableFacesTest.java
@@ -35,6 +35,7 @@ import lombok.Getter;
 import org.apache.myfaces.test.mock.MockExternalContext;
 import org.apache.myfaces.test.mock.MockFacesContext;
 import org.apache.myfaces.test.mock.MockHttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import static de.cuioss.test.jsf.util.ConfigurationHelper.*;
@@ -118,6 +119,18 @@ public class ConfigurableFacesTest {
         getApplicationConfigDecorator().getMockNavigationHandler();
         getApplicationConfigDecorator().getMockSearchExpressionHandler();
         getApplicationConfigDecorator().getMockResourceHandler();
+    }
+
+    /**
+     * Tears down the JSF runtime after each test. This releases the
+     * {@link MockFacesContext} (avoiding thread-local leaks into later tests),
+     * releases the {@link jakarta.faces.FactoryFinder} factories and restores the
+     * original thread-context classloader. Mirrors
+     * {@code JsfSetupExtension#afterEach}.
+     */
+    @AfterEach
+    protected void tearDownJsfRuntime() {
+        runtimeSetup.tearDown();
     }
 
     protected FacesContext getFacesContext() {

--- a/src/main/java/de/cuioss/test/jsf/util/ConfigurationHelper.java
+++ b/src/main/java/de/cuioss/test/jsf/util/ConfigurationHelper.java
@@ -83,8 +83,13 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureComponents(registry));
-        getBareJsfTestSetups(configurations)
+        getBareJsfTestSetups(configurations, ComponentConfigurator.class)
             .forEach(instance -> instance.configureComponents(registry));
+        // LIFE-6: a test class migrated to the bare JsfTestSetup replacement (without
+        // implementing the deprecated ComponentConfigurator) must still be called.
+        if (!(testClass instanceof ComponentConfigurator) && testClass instanceof JsfTestSetup setup) {
+            setup.configureComponents(registry);
+        }
     }
 
     /**
@@ -110,8 +115,13 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureApplication(registry));
-        getBareJsfTestSetups(configurations)
+        getBareJsfTestSetups(configurations, ApplicationConfigurator.class)
             .forEach(instance -> instance.configureApplication(registry));
+        // LIFE-6: a test class migrated to the bare JsfTestSetup replacement (without
+        // implementing the deprecated ApplicationConfigurator) must still be called.
+        if (!(testClass instanceof ApplicationConfigurator) && testClass instanceof JsfTestSetup setup) {
+            setup.configureApplication(registry);
+        }
     }
 
     /**
@@ -137,8 +147,13 @@ public final class ConfigurationHelper {
             instances.add(configurator);
         }
         instances.forEach(instance -> instance.configureRequest(registry));
-        getBareJsfTestSetups(configurations)
+        getBareJsfTestSetups(configurations, RequestConfigurator.class)
             .forEach(instance -> instance.configureRequest(registry));
+        // LIFE-6: a test class migrated to the bare JsfTestSetup replacement (without
+        // implementing the deprecated RequestConfigurator) must still be called.
+        if (!(testClass instanceof RequestConfigurator) && testClass instanceof JsfTestSetup setup) {
+            setup.configureRequest(registry);
+        }
     }
 
     /**
@@ -162,25 +177,28 @@ public final class ConfigurationHelper {
     }
 
     /**
-     * Collects instances of bare {@link JsfTestSetup} implementors — types referenced by
-     * {@link JsfTestConfiguration#value()} that do <em>not</em> implement any of the legacy
-     * sub-interfaces ({@link ApplicationConfigurator}, {@link ComponentConfigurator},
-     * {@link RequestConfigurator}). These implementors are dispatched via the
-     * {@link JsfTestSetup} default methods for all configuration phases, while legacy
-     * implementors are handled by the per-sub-interface dispatch path to avoid
-     * redundant instantiations.
+     * Collects {@link JsfTestSetup} implementors that should receive the callback for a
+     * <em>single</em> configuration phase via the {@link JsfTestSetup} default methods.
+     * A type is included unless it implements the legacy sub-interface that handles this
+     * very phase ({@code legacyPhaseInterface}); that is the only case in which it would
+     * be double-dispatched. A type that implements a legacy interface for a
+     * <em>different</em> phase (e.g. an {@link ApplicationConfigurator} that also overrides
+     * {@code configureComponents}) is therefore still invoked for this phase (LIFE-4).
+     * <p>
+     * Each configured class is instantiated once per phase, so implementations must be
+     * stateless.
      *
-     * @param configurations the previously extracted annotations, must not be null
-     * @return list of {@link JsfTestSetup} instances that do not implement any legacy
-     *         configurator sub-interface
+     * @param configurations      the previously extracted annotations, must not be null
+     * @param legacyPhaseInterface the legacy configurator interface handling the current
+     *                             phase; implementors of it are excluded to avoid a double call
+     * @return list of {@link JsfTestSetup} instances to dispatch for the current phase
      */
-    private static List<JsfTestSetup> getBareJsfTestSetups(final Collection<JsfTestConfiguration> configurations) {
+    private static List<JsfTestSetup> getBareJsfTestSetups(final Collection<JsfTestConfiguration> configurations,
+        final Class<? extends JsfTestSetup> legacyPhaseInterface) {
         final List<JsfTestSetup> instances = new ArrayList<>();
         for (final JsfTestConfiguration config : configurations) {
             for (final Class<? extends JsfTestSetup> type : config.value()) {
-                if (!ApplicationConfigurator.class.isAssignableFrom(type)
-                    && !ComponentConfigurator.class.isAssignableFrom(type)
-                    && !RequestConfigurator.class.isAssignableFrom(type)) {
+                if (!legacyPhaseInterface.isAssignableFrom(type)) {
                     instances.add(new DefaultInstantiator<>(type).newInstance());
                 }
             }

--- a/src/main/java/de/cuioss/test/jsf/util/JsfRuntimeSetup.java
+++ b/src/main/java/de/cuioss/test/jsf/util/JsfRuntimeSetup.java
@@ -16,6 +16,7 @@
 package de.cuioss.test.jsf.util;
 
 import de.cuioss.test.jsf.mocks.*;
+import de.cuioss.tools.logging.CuiLogger;
 import jakarta.faces.FactoryFinder;
 import jakarta.faces.application.Application;
 import jakarta.faces.application.ApplicationFactory;
@@ -29,6 +30,7 @@ import org.apache.myfaces.test.mock.*;
 import org.apache.myfaces.test.mock.lifecycle.MockLifecycle;
 import org.apache.myfaces.test.mock.lifecycle.MockLifecycleFactory;
 
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -40,6 +42,8 @@ import java.net.URLClassLoader;
  * @author Oliver Wolff
  */
 public class JsfRuntimeSetup {
+
+    private static final CuiLogger LOGGER = new CuiLogger(JsfRuntimeSetup.class);
 
     @Getter
     @Setter
@@ -92,6 +96,8 @@ public class JsfRuntimeSetup {
     // Thread context class loader saved and restored after each test
     private ClassLoader threadContextClassLoader = null;
     private boolean classLoaderSet = false;
+    // The URLClassLoader installed during setUp; kept so it can be closed on tearDown
+    private URLClassLoader jsfClassLoader = null;
 
     /**
      * <p>
@@ -126,6 +132,7 @@ public class JsfRuntimeSetup {
             facesContext.release();
         }
         facesContext = null;
+        facesContextFactory = null;
         lifecycle = null;
         lifecycleFactory = null;
         renderKit = null;
@@ -145,8 +152,14 @@ public class JsfRuntimeSetup {
      * cases, the default classloader cannot be properly set.
      */
     private void setUpClassloader() {
+        // Guard against a repeated setUp() without an intervening tearDown() overwriting
+        // the saved original classloader (which could then never be restored).
+        if (classLoaderSet) {
+            return;
+        }
         threadContextClassLoader = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(new URLClassLoader(new URL[0], this.getClass().getClassLoader()));
+        jsfClassLoader = new URLClassLoader(new URL[0], this.getClass().getClassLoader());
+        Thread.currentThread().setContextClassLoader(jsfClassLoader);
         classLoaderSet = true;
     }
 
@@ -293,6 +306,14 @@ public class JsfRuntimeSetup {
             Thread.currentThread().setContextClassLoader(threadContextClassLoader);
             threadContextClassLoader = null;
             classLoaderSet = false;
+        }
+        if (jsfClassLoader != null) {
+            try {
+                jsfClassLoader.close();
+            } catch (IOException e) {
+                LOGGER.debug("Unable to close the JSF test class-loader", e);
+            }
+            jsfClassLoader = null;
         }
     }
 }

--- a/src/test/java/de/cuioss/test/jsf/config/DeterministicConfigurationOrderTest.java
+++ b/src/test/java/de/cuioss/test/jsf/config/DeterministicConfigurationOrderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.config;
+
+import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
+import de.cuioss.test.jsf.junit5.EnableJsfEnvironment;
+import jakarta.faces.context.FacesContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression test for LIFE-1: multiple {@link JsfTestConfiguration} annotations must
+ * be applied in their declared order (deterministic last-wins). Before the fix the
+ * purpose-built {@code LinkedHashSet} was re-collected into a {@code HashSet}, so when
+ * two configurations touched the same navigation case the winner varied between runs.
+ * <p>
+ * Located in the {@code config} package because the {@code @Repeatable} container
+ * {@code JsfTestConfigurations} is package-private.
+ */
+@EnableJsfEnvironment
+@JsfTestConfiguration(DeterministicConfigurationOrderTest.ConfigA.class)
+@JsfTestConfiguration(DeterministicConfigurationOrderTest.ConfigB.class)
+class DeterministicConfigurationOrderTest {
+
+    static final String OUTCOME = "sharedOutcome";
+
+    @Test
+    void lastConfigurationWinsDeterministically(FacesContext facesContext,
+        ApplicationConfigDecorator applicationConfig) {
+        var handler = applicationConfig.getMockNavigationHandler();
+        var navigationCase = handler.getNavigationCase(facesContext, null, OUTCOME);
+
+        assertNotNull(navigationCase, "The shared navigation case must be registered");
+        assertEquals("/viewB.xhtml", navigationCase.getToViewId(facesContext),
+            "The last-declared configuration (ConfigB) must win deterministically");
+    }
+
+    /** Registers the shared outcome to view A. */
+    public static class ConfigA implements JsfTestSetup {
+        @Override
+        public void configureApplication(ApplicationConfigDecorator applicationConfig) {
+            applicationConfig.registerNavigationCase(OUTCOME, "/viewA.xhtml");
+        }
+    }
+
+    /** Registers the shared outcome to view B (declared last, must win). */
+    public static class ConfigB implements JsfTestSetup {
+        @Override
+        public void configureApplication(ApplicationConfigDecorator applicationConfig) {
+            applicationConfig.registerNavigationCase(OUTCOME, "/viewB.xhtml");
+        }
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecoratorTest.java
+++ b/src/test/java/de/cuioss/test/jsf/config/decorator/RequestConfigDecoratorTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableJsfEnvironment
@@ -115,5 +116,15 @@ class RequestConfigDecoratorTest {
         decorator.addRequestCookie(new Cookie("coo", "kie"));
         assertNotNull(request.getCookies(), "Cookies should not be there");
         assertEquals(1, request.getCookies().length);
+    }
+
+    @Test
+    @DisplayName("Should set the query string and return itself for fluent chaining (LIFE-9)")
+    void shouldSetQueryString(RequestConfigDecorator decorator, ExternalContext externalContext) {
+        var result = decorator.setQueryString("foo=bar");
+
+        assertSame(decorator, result, "setQueryString must return the decorator to enable fluent chaining");
+        assertEquals("foo=bar", ((HttpServletRequest) externalContext.getRequest()).getQueryString(),
+            "The query string should be set on the request");
     }
 }

--- a/src/test/java/de/cuioss/test/jsf/converter/ConverterConfigureComponentsRegressionTest.java
+++ b/src/test/java/de/cuioss/test/jsf/converter/ConverterConfigureComponentsRegressionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.converter;
+
+import de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator;
+import de.cuioss.test.jsf.mocks.ReverseConverter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for LIFE-5: an {@link AbstractConverterTest} subclass overriding
+ * {@link #configureComponents(ComponentConfigDecorator)} must actually have that
+ * override invoked before the converter tests run. Previously the method was a
+ * documented no-op because the base class never dispatched it.
+ */
+class ConverterConfigureComponentsRegressionTest extends AbstractConverterTest<ReverseConverter, String> {
+
+    private boolean configureComponentsCalled;
+
+    @Override
+    protected void configureComponents(final ComponentConfigDecorator decorator) {
+        super.configureComponents(decorator);
+        configureComponentsCalled = true;
+    }
+
+    @Override
+    public void populate(TestItems<String> testItems) {
+        testItems.addRoundtripValues("abc");
+    }
+
+    @Test
+    void configureComponentsOverrideIsInvoked() {
+        assertTrue(configureComponentsCalled,
+            "The configureComponents override must be invoked by initConverter (LIFE-5)");
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/util/ConfigurableFacesTestLifecycleTest.java
+++ b/src/test/java/de/cuioss/test/jsf/util/ConfigurableFacesTestLifecycleTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Exercises the {@link ConfigurableFacesTest} setup/teardown lifecycle (LIFE-3). The
+ * inherited {@code @BeforeEach} builds the JSF runtime and the inherited
+ * {@code @AfterEach} tears it down again; running two test methods ensures the runtime
+ * is re-created cleanly for each test rather than leaking a released
+ * {@code MockFacesContext} into the next.
+ */
+class ConfigurableFacesTestLifecycleTest extends ConfigurableFacesTest {
+
+    @Test
+    void shouldProvideConfiguredEnvironment() {
+        assertNotNull(getFacesContext(), "FacesContext should be available");
+        assertNotNull(getApplication(), "Application should be available");
+        assertNotNull(getExternalContext(), "ExternalContext should be available");
+    }
+
+    @Test
+    void shouldProvideFreshEnvironmentPerTest() {
+        // A second test method verifies setup runs again after the previous teardown.
+        assertNotNull(getFacesContext(), "FacesContext should be re-created for each test");
+        assertNotNull(getRequestConfigDecorator(), "RequestConfigDecorator should be available");
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/util/ConfigurationDispatchRegressionTest.java
+++ b/src/test/java/de/cuioss/test/jsf/util/ConfigurationDispatchRegressionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.util;
+
+import de.cuioss.test.jsf.config.ApplicationConfigurator;
+import de.cuioss.test.jsf.config.JsfTestConfiguration;
+import de.cuioss.test.jsf.config.JsfTestSetup;
+import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
+import de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator;
+import de.cuioss.test.jsf.junit5.EnableJsfEnvironment;
+import jakarta.faces.context.FacesContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for LIFE-4: a configuration class that implements one legacy
+ * configurator interface ({@link ApplicationConfigurator}) and also overrides a
+ * <em>different</em> {@link JsfTestSetup} phase ({@code configureComponents}) must
+ * still have that override invoked.
+ */
+@EnableJsfEnvironment
+@JsfTestConfiguration(ConfigurationDispatchRegressionTest.MixedConfig.class)
+class ConfigurationDispatchRegressionTest {
+
+    @Test
+    void mixedConfiguratorOtherPhaseInvoked(FacesContext facesContext) {
+        assertTrue(MixedConfig.applicationCalled, "configureApplication must be dispatched");
+        assertTrue(MixedConfig.componentsCalled,
+            "configureComponents override on a legacy ApplicationConfigurator must be dispatched (LIFE-4)");
+    }
+
+    /** Implements the legacy {@link ApplicationConfigurator} but also overrides another phase. */
+    public static class MixedConfig implements ApplicationConfigurator {
+        static boolean applicationCalled;
+        static boolean componentsCalled;
+
+        @Override
+        public void configureApplication(ApplicationConfigDecorator applicationConfig) {
+            applicationCalled = true;
+        }
+
+        @Override
+        public void configureComponents(ComponentConfigDecorator componentConfig) {
+            componentsCalled = true;
+        }
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/util/JsfRuntimeSetupTest.java
+++ b/src/test/java/de/cuioss/test/jsf/util/JsfRuntimeSetupTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Direct unit test for {@link JsfRuntimeSetup} covering the setup/teardown lifecycle
+ * and the LIFE-8 hardening: a repeated {@code setUp()} without an intervening
+ * {@code tearDown()} must not overwrite the saved thread-context classloader.
+ */
+@DisplayName("JsfRuntimeSetup")
+class JsfRuntimeSetupTest {
+
+    @Test
+    @DisplayName("setUp builds the JSF runtime and tearDown releases it")
+    void shouldSetUpAndTearDown() {
+        var originalClassLoader = Thread.currentThread().getContextClassLoader();
+        var setup = new JsfRuntimeSetup();
+        try {
+            setup.setUp();
+
+            assertNotNull(setup.getFacesContext(), "FacesContext should be created");
+            assertNotNull(setup.getApplication(), "Application should be created");
+            assertNotNull(setup.getExternalContext(), "ExternalContext should be created");
+            assertNotSame(originalClassLoader, Thread.currentThread().getContextClassLoader(),
+                "A dedicated thread-context classloader should be installed");
+
+            // LIFE-8: a second setUp without tearDown must not overwrite the saved
+            // original classloader (the guard makes it a no-op for the classloader).
+            assertDoesNotThrow(setup::setUp, "A repeated setUp must be tolerated");
+        } finally {
+            setup.tearDown();
+        }
+
+        assertNull(setup.getFacesContext(), "tearDown should release the FacesContext");
+        assertNull(setup.getFacesContextFactory(), "tearDown should null the FacesContextFactory");
+        assertSame(originalClassLoader, Thread.currentThread().getContextClassLoader(),
+            "tearDown should restore the original thread-context classloader");
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/util/SingleClassConfigurationApplicationTest.java
+++ b/src/test/java/de/cuioss/test/jsf/util/SingleClassConfigurationApplicationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.util;
+
+import de.cuioss.test.jsf.config.JsfTestConfiguration;
+import de.cuioss.test.jsf.config.JsfTestSetup;
+import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
+import de.cuioss.test.jsf.junit5.EnableJsfEnvironment;
+import jakarta.faces.context.FacesContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for LIFE-2: a class-level {@link JsfTestConfiguration} must be
+ * applied exactly once per test. Before the fix, {@code beforeEach} re-applied the
+ * class-level configuration that {@code postProcessTestInstance} had already applied,
+ * so a non-idempotent configurator ran twice per test.
+ * <p>
+ * The class deliberately declares a single test method so the static counter reflects
+ * exactly one test instance.
+ */
+@EnableJsfEnvironment
+@JsfTestConfiguration(SingleClassConfigurationApplicationTest.CountingConfig.class)
+class SingleClassConfigurationApplicationTest {
+
+    @Test
+    void classLevelConfigurationAppliedExactlyOnce(FacesContext facesContext) {
+        assertEquals(1, CountingConfig.applicationCount,
+            "A class-level @JsfTestConfiguration must be applied exactly once per test");
+    }
+
+    /** Counts how often {@code configureApplication} is invoked. */
+    public static class CountingConfig implements JsfTestSetup {
+        static int applicationCount;
+
+        @Override
+        public void configureApplication(ApplicationConfigDecorator applicationConfig) {
+            applicationCount++;
+        }
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/util/TestClassAsJsfTestSetupTest.java
+++ b/src/test/java/de/cuioss/test/jsf/util/TestClassAsJsfTestSetupTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.util;
+
+import de.cuioss.test.jsf.config.JsfTestSetup;
+import de.cuioss.test.jsf.config.decorator.ApplicationConfigDecorator;
+import de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator;
+import de.cuioss.test.jsf.config.decorator.RequestConfigDecorator;
+import de.cuioss.test.jsf.junit5.EnableJsfEnvironment;
+import jakarta.faces.context.FacesContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for LIFE-6: a test class that itself implements the (non-deprecated)
+ * {@link JsfTestSetup} replacement — without implementing any legacy configurator
+ * sub-interface — must have all three {@code configure*} callbacks dispatched.
+ */
+@EnableJsfEnvironment
+class TestClassAsJsfTestSetupTest implements JsfTestSetup {
+
+    private boolean applicationCalled;
+    private boolean componentsCalled;
+    private boolean requestCalled;
+
+    @Override
+    public void configureApplication(ApplicationConfigDecorator applicationConfig) {
+        applicationCalled = true;
+    }
+
+    @Override
+    public void configureComponents(ComponentConfigDecorator componentConfig) {
+        componentsCalled = true;
+    }
+
+    @Override
+    public void configureRequest(RequestConfigDecorator requestConfig) {
+        requestCalled = true;
+    }
+
+    @Test
+    void shouldDispatchAllPhasesToTestClass(FacesContext facesContext) {
+        assertTrue(applicationCalled, "configureApplication must be dispatched to the test class");
+        assertTrue(componentsCalled, "configureComponents must be dispatched to the test class");
+        assertTrue(requestCalled, "configureRequest must be dispatched to the test class");
+    }
+}


### PR DESCRIPTION
## Cluster 2 — Lifecycle & configuration infrastructure (PR-2)

Fixes nondeterminism, double execution and resource leaks in the JUnit-5 extension and configuration dispatch, per `doc/review-26-07-04.md`.

### Findings addressed
| ID | Fix |
|----|-----|
| LIFE-1 [M] | `JsfSetupExtension` preserves `LinkedHashSet` config ordering (removed the `Collectors.toSet()` re-collection) |
| LIFE-2 [M] | `beforeEach` applies only *method-level* annotations → class-level configs no longer applied twice per test |
| LIFE-3 [M] | `ConfigurableFacesTest` now tears the JSF runtime down via `@AfterEach` |
| LIFE-4 [M] | `ConfigurationHelper` dispatches bare `JsfTestSetup` phases per-phase, so a legacy configurator overriding another phase is still called |
| LIFE-5 [M] | `AbstractConverterTest` invokes `configureComponents` via an injected `ComponentConfigDecorator` |
| LIFE-6 [m] | `ConfigurationHelper` also dispatches on `testClass instanceof JsfTestSetup` |
| LIFE-7 [m] | `@Repeatable` containers now target `METHOD` |
| LIFE-8 [m] | `JsfRuntimeSetup` closes the `URLClassLoader`, nulls `facesContextFactory`, guards the saved classloader; `PER_CLASS` documented as unsupported; innermost-annotation comment corrected |
| LIFE-9 [m] | `RequestConfigDecorator.setQueryString` is fluent; Javadoc fixes |

### Tests
New regression tests for LIFE-1 (deterministic ordering), LIFE-2 (single application), LIFE-3 (setup/teardown lifecycle), LIFE-4 (mixed configurator), LIFE-5 (converter override invoked), LIFE-6 (test class as `JsfTestSetup`), plus a direct `JsfRuntimeSetup` test. Full `./mvnw clean install` green (271 tests); new-code coverage ≈ 88%.

### ⚠️ Behavior-change note (for release notes / migration)
LIFE-2 (configurators now run once per test) and LIFE-3 (runtime is now torn down after each test) change observable behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y95DNbN4fZHSdaR4wAckzN)_