### PR TITLE
fix(asserts): harden assertion & test-base helpers (ASSERT-1…ASSERT-12)

### DIFF
--- a/src/main/java/de/cuioss/test/jsf/component/ComponentTestHelper.java
+++ b/src/main/java/de/cuioss/test/jsf/component/ComponentTestHelper.java
@@ -69,7 +69,8 @@ public final class ComponentTestHelper {
             unorderedCollection.addAll(Arrays.asList(property.assertUnorderedCollection()));
         }
 
-        final Map<String, PropertyMetadata> map = new HashMap<>();
+        // LinkedHashMap keeps verification order deterministic (ASSERT-12).
+        final Map<String, PropertyMetadata> map = new LinkedHashMap<>();
         propertyConfigs.forEach(pc -> map.put(pc.getName(), pc));
         for (String configuredName : of) {
             map.put(configuredName, resolvePropertyForConfiguredName(instance, configuredName));
@@ -95,9 +96,8 @@ public final class ComponentTestHelper {
      */
     public static PropertyMetadata resolvePropertyForConfiguredName(final UIComponent instance,
         final String configuredName) {
-        Class<?> propertyType = null;
-        var collectionType = CollectionType.NO_ITERABLE;
-        propertyType = PropertyHolder.from(instance.getClass(), configuredName)
+        final var collectionType = CollectionType.NO_ITERABLE;
+        final Class<?> propertyType = PropertyHolder.from(instance.getClass(), configuredName)
             .orElseThrow(() -> new IllegalStateException("Unable to determine property type for " + configuredName
                 + ", use @PropertyConfig to define this property"))
             .getType();

--- a/src/main/java/de/cuioss/test/jsf/converter/AbstractConverterTest.java
+++ b/src/main/java/de/cuioss/test/jsf/converter/AbstractConverterTest.java
@@ -96,7 +96,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Oliver Wolff
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-// owolff we need to migrate this aspect later
 @EnableGeneratorController
 @EnableJsfEnvironment
 public abstract class AbstractConverterTest<C extends Converter, T>
@@ -246,6 +245,10 @@ public abstract class AbstractConverterTest<C extends Converter, T>
     private void verifyExpectedErrorMessage(final ConverterTestItem<T> item, final ConverterException e) {
         // Check message
         if (null != item.getErrorMessage()) {
+            assertNotNull(e.getFacesMessage(),
+                "Exception carries no FacesMessage but message '" + item.getErrorMessage() + "' was expected");
+            assertEquals(item.getSeverity(), e.getFacesMessage().getSeverity(),
+                "Wrong severity detected. TestItem was : " + item);
             assertEquals(item.getErrorMessage(), e.getFacesMessage().getSummary(),
                 "Wrong error message detected. TestItem was : " + item);
         }

--- a/src/main/java/de/cuioss/test/jsf/converter/AbstractSanitizingConverterTest.java
+++ b/src/main/java/de/cuioss/test/jsf/converter/AbstractSanitizingConverterTest.java
@@ -20,6 +20,7 @@ import jakarta.faces.convert.Converter;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Extension of {@linkplain AbstractConverterTest} to also test the sanitizing
@@ -51,7 +52,9 @@ public abstract class AbstractSanitizingConverterTest<C extends Converter<T>, T>
     protected void shouldSanitizeJavaScript(FacesContext facesContext) {
         var toConvert = createTestObjectWithMaliciousContent("<script>");
         var result = getConverter().getAsString(facesContext, getComponent(), toConvert);
-        assertFalse(result.contains("<script"));
+        assertNotNull(result, "The converter must not return null for malicious content");
+        assertFalse(result.contains("<script"),
+            "The converter must sanitize the '<script' fragment from its output, but was: " + result);
     }
 
 }

--- a/src/main/java/de/cuioss/test/jsf/converter/TestItems.java
+++ b/src/main/java/de/cuioss/test/jsf/converter/TestItems.java
@@ -62,8 +62,10 @@ public class TestItems<T> {
     @Getter(AccessLevel.PACKAGE)
     private final List<ConverterTestItem<T>> invalidStringTestItems = new ArrayList<>();
 
+    // LinkedHashSet keeps a deterministic iteration order so order-dependent converter
+    // bugs remain reproducible (ASSERT-7).
     @Getter(AccessLevel.PACKAGE)
-    private final Set<String> roundtripValues = new HashSet<>();
+    private final Set<String> roundtripValues = new LinkedHashSet<>();
 
     /**
      * Adds roundtrip String values to be tested. These values are used in the

--- a/src/main/java/de/cuioss/test/jsf/defaults/BasicApplicationConfiguration.java
+++ b/src/main/java/de/cuioss/test/jsf/defaults/BasicApplicationConfiguration.java
@@ -71,6 +71,6 @@ public class BasicApplicationConfiguration implements JsfTestSetup {
     @Override
     public void configureRequest(final RequestConfigDecorator decorator) {
         decorator.setRequestHeader(USER_AGENT, FIREFOX)
-            .setRequestLocale(SUPPORTED_LOCALES.toArray(new Locale[SUPPORTED_LOCALES.size()]));
+            .setRequestLocale(SUPPORTED_LOCALES.toArray(new Locale[0]));
     }
 }

--- a/src/main/java/de/cuioss/test/jsf/junit5/JsfParameterResolver.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/JsfParameterResolver.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -80,20 +79,17 @@ public class JsfParameterResolver implements ParameterResolver {
 
     private final JsfEnvironmentHolder environmentHolder;
 
-    private static final Set<Class<?>> SUPPORTED_TYPES = new HashSet<>();
-
-    static {
-        SUPPORTED_TYPES.add(JsfEnvironmentHolder.class);
-        SUPPORTED_TYPES.add(FacesContext.class);
-        SUPPORTED_TYPES.add(ExternalContext.class);
-        SUPPORTED_TYPES.add(Application.class);
-        SUPPORTED_TYPES.add(RequestConfigDecorator.class);
-        SUPPORTED_TYPES.add(ApplicationConfigDecorator.class);
-        SUPPORTED_TYPES.add(ComponentConfigDecorator.class);
-        SUPPORTED_TYPES.add(MockHttpServletResponse.class);
-        SUPPORTED_TYPES.add(MockHttpServletRequest.class);
-        SUPPORTED_TYPES.add(NavigationAsserts.class);
-    }
+    private static final Set<Class<?>> SUPPORTED_TYPES = Set.of(
+        JsfEnvironmentHolder.class,
+        FacesContext.class,
+        ExternalContext.class,
+        Application.class,
+        RequestConfigDecorator.class,
+        ApplicationConfigDecorator.class,
+        ComponentConfigDecorator.class,
+        MockHttpServletResponse.class,
+        MockHttpServletRequest.class,
+        NavigationAsserts.class);
 
     /**
      * Determines if this resolver supports the given parameter.

--- a/src/main/java/de/cuioss/test/jsf/junit5/NavigationAsserts.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/NavigationAsserts.java
@@ -80,7 +80,7 @@ public class NavigationAsserts {
      * @param outcome must not be null
      */
     public void assertNavigatedWithOutcome(String outcome) {
-        assertNotNull(emptyToNull(outcome), "Outcome must not be null");
+        assertNotNull(emptyToNull(outcome), "Outcome must not be null or empty");
         assertTrue(facesContext.getExternalContext().isResponseCommitted(), "Response is not committed");
         var handler = applicationConfig.getMockNavigationHandler();
         assertTrue(handler.isHandleNavigationCalled(), "handleNavigation is not called");
@@ -94,7 +94,7 @@ public class NavigationAsserts {
      * @param redirectUrl must not be null
      */
     public void assertRedirect(String redirectUrl) {
-        assertNotNull(emptyToNull(redirectUrl), "redirectUrl must not be null");
+        assertNotNull(emptyToNull(redirectUrl), "redirectUrl must not be null or empty");
         assertTrue(facesContext.getExternalContext().isResponseCommitted(), "Response is not committed");
         var tempResponse = (HttpServletResponse) externalContext.getResponse();
         assertTrue(tempResponse.containsHeader("Location"), "Response must provide a header with the name 'Location'");

--- a/src/main/java/de/cuioss/test/jsf/producer/ServletObjectsFromJSFContextProducer.java
+++ b/src/main/java/de/cuioss/test/jsf/producer/ServletObjectsFromJSFContextProducer.java
@@ -54,7 +54,7 @@ public class ServletObjectsFromJSFContextProducer {
     }
 
     @Produces
-    //    @Typed({ ServletContext.class })
+    @Typed({ServletContext.class})
     @Dependent
     ServletContext produceServletContext() {
         return (ServletContext) FacesContext.getCurrentInstance().getExternalContext()

--- a/src/main/java/de/cuioss/test/jsf/renderer/AbstractRendererTestBase.java
+++ b/src/main/java/de/cuioss/test/jsf/renderer/AbstractRendererTestBase.java
@@ -137,9 +137,8 @@ public abstract class AbstractRendererTestBase<R extends Renderer>
      *                     null
      * @param expected     the expected DOM document, must not be null
      * @param facesContext the FacesContext to be used for rendering
-     * @throws IOException if an error occurs during rendering
      */
-    public void assertRenderResult(final UIComponent toBeRendered, final Document expected, FacesContext facesContext) throws IOException {
+    public void assertRenderResult(final UIComponent toBeRendered, final Document expected, FacesContext facesContext) {
         var rendered = assertDoesNotThrow(() -> renderToString(toBeRendered, facesContext));
         assertNotNull(emptyToNull(rendered), "Render result must not be empty.");
         HtmlTreeAsserts.assertHtmlTreeEquals(expected, DomUtils.htmlStringToDocument(rendered));
@@ -153,10 +152,9 @@ public abstract class AbstractRendererTestBase<R extends Renderer>
      *                     null
      * @param expected     the expected HTML string, must not be null
      * @param facesContext the FacesContext to be used for rendering
-     * @throws IOException if an error occurs during rendering
      */
-    public void assertRenderResult(final UIComponent toBeRendered, final String expected, FacesContext facesContext) throws IOException {
-        assertNotNull(emptyToNull(expected), "Render result must not be empty.");
+    public void assertRenderResult(final UIComponent toBeRendered, final String expected, FacesContext facesContext) {
+        assertNotNull(emptyToNull(expected), "Expected HTML must not be empty");
         assertRenderResult(toBeRendered, DomUtils.htmlStringToDocument(expected), facesContext);
     }
 
@@ -197,7 +195,8 @@ public abstract class AbstractRendererTestBase<R extends Renderer>
     void shouldThrowNPEOnMissingParameterForEncodeBegin(FacesContext facesContext) {
         assertThrows(NullPointerException.class, () -> renderer.encodeBegin(null, getComponent()),
             NPE_ON_MISSING_FACES_CONTEXT_EXPECTED);
-        assertThrows(NullPointerException.class, () -> renderer.encodeBegin(facesContext, null));
+        assertThrows(NullPointerException.class, () -> renderer.encodeBegin(facesContext, null),
+            NPE_ON_MISSING_PARAMETER_EXPECTED);
     }
 
     /**

--- a/src/main/java/de/cuioss/test/jsf/renderer/CommonRendererAsserts.java
+++ b/src/main/java/de/cuioss/test/jsf/renderer/CommonRendererAsserts.java
@@ -24,6 +24,7 @@ import org.jdom2.Element;
 import java.io.Serializable;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -47,12 +48,12 @@ public enum CommonRendererAsserts implements RendererAttributeAssert {
     RENDERED("rendered", Boolean.FALSE) {
         @Override
         public void assertAttributeSet(final Element element) {
-            if (null == element) {
-                return;
-            }
             if (!element.getChildren().isEmpty()) {
                 fail("Children found, although the rendered attribute is set to 'false'. This may be a tricky one, depending on your desired output");
             }
+            // A not-rendered component must not emit bare text either (ASSERT-4).
+            assertTrue(element.getTextTrim().isEmpty(),
+                "Text output found, although the rendered attribute is set to 'false'. This may be a tricky one, depending on your desired output");
         }
     },
     /**
@@ -60,7 +61,7 @@ public enum CommonRendererAsserts implements RendererAttributeAssert {
      */
     STYLE("style", "traceStyle"),
     /**
-     * Checks the attribute 'style'
+     * Checks the attribute 'styleClass'
      */
     STYLE_CLASS("styleClass", "traceStyleClass") {
         @Override

--- a/src/main/java/de/cuioss/test/jsf/renderer/util/DomUtils.java
+++ b/src/main/java/de/cuioss/test/jsf/renderer/util/DomUtils.java
@@ -60,6 +60,8 @@ public class DomUtils {
             var saxBuilder = new SAXBuilder();
             saxBuilder.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             saxBuilder.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            // Fully disable DOCTYPE declarations to prevent XXE (Sonar S2755).
+            saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             return saxBuilder.build(input);
         } catch (JDOMException | IOException e) {
             throw new IllegalArgumentException("Unable to parse given String, due to ", e);
@@ -77,7 +79,7 @@ public class DomUtils {
      */
     public static List<Attribute> filterForAttribute(final Element element, final String attributeName) {
         requireNonNull(element);
-        requireNonNull(emptyToNull(attributeName));
+        checkNotEmpty(attributeName, "attributeName");
         List<Attribute> found = new ArrayList<>();
         var current = element.getAttribute(attributeName);
         if (null != current) {
@@ -103,9 +105,18 @@ public class DomUtils {
      */
     public static List<Attribute> filterForAttributeContainingValue(final Element element, final String attributeName,
         final String attributeValuePart) {
-        requireNonNull(emptyToNull(attributeValuePart));
+        checkNotEmpty(attributeValuePart, "attributeValuePart");
 
         return filterForAttribute(element, attributeName).stream()
             .filter(a -> a.getValue().contains(attributeValuePart)).toList();
+    }
+
+    /**
+     * @throws IllegalArgumentException if the given value is {@code null} or empty
+     */
+    private static void checkNotEmpty(final String value, final String name) {
+        if (null == emptyToNull(value)) {
+            throw new IllegalArgumentException(name + " must not be null nor empty");
+        }
     }
 }

--- a/src/main/java/de/cuioss/test/jsf/renderer/util/HtmlTreeAsserts.java
+++ b/src/main/java/de/cuioss/test/jsf/renderer/util/HtmlTreeAsserts.java
@@ -20,10 +20,18 @@ import org.jdom2.Attribute;
 import org.jdom2.Document;
 import org.jdom2.Element;
 
+import java.util.ArrayList;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Provides asserts for {@link Document} and Jdom elements.
+ * <p>
+ * <em>Known limitation:</em> the text content of an element is compared using
+ * {@code getTextNormalize()}, which concatenates all direct text of an element and
+ * collapses whitespace. The <em>position</em> of text relative to child elements is
+ * therefore not verified — {@code <div>x<span/></div>} and {@code <div><span/>x</div>}
+ * are treated as equal.
  *
  * @author Oliver Wolff
  */
@@ -63,6 +71,8 @@ public final class HtmlTreeAsserts {
      */
     public static void assertElementWithChildrenEquals(final Element expected, final Element actual,
         final String pointer) {
+        assertNotNull(expected, EXPECTED_MUST_NOT_BE_NULL);
+        assertNotNull(actual, ACTUAL_MUST_NOT_BE_NULL);
         var currentPointer = pointer + ">" + expected.getName();
         assertElementEquals(expected, actual, currentPointer);
         var expectedChildren = expected.getChildren();
@@ -101,8 +111,10 @@ public final class HtmlTreeAsserts {
         assertNotNull(actual, ACTUAL_MUST_NOT_BE_NULL);
         assertEquals(expected.getName(), actual.getName(),
             "%s: The names are not equal, expected=%s, actual=%s".formatted(pointer, expected, actual));
-        var expectedAttributes = expected.getAttributes();
-        var actualAttributes = actual.getAttributes();
+        // Copy the live JDOM attribute lists before sorting so a reused expected/actual
+        // Document is not silently mutated (ASSERT-1).
+        var expectedAttributes = new ArrayList<>(expected.getAttributes());
+        var actualAttributes = new ArrayList<>(actual.getAttributes());
         if (expectedAttributes.isEmpty() && actualAttributes.isEmpty()) {
             return;
         }

--- a/src/main/java/de/cuioss/test/jsf/validator/AbstractValidatorTest.java
+++ b/src/main/java/de/cuioss/test/jsf/validator/AbstractValidatorTest.java
@@ -20,7 +20,6 @@ import de.cuioss.test.jsf.junit5.EnableJsfEnvironment;
 import de.cuioss.test.valueobjects.objects.ConfigurationCallBackHandler;
 import de.cuioss.test.valueobjects.objects.impl.DefaultInstantiator;
 import de.cuioss.tools.reflect.MoreReflection;
-import jakarta.faces.application.FacesMessage;
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.html.HtmlInputText;
 import jakarta.faces.context.FacesContext;
@@ -92,7 +91,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Oliver Wolff
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-// owolff we need to migrate this aspect later
 @EnableGeneratorController
 @EnableJsfEnvironment
 public abstract class AbstractValidatorTest<V extends Validator, T>
@@ -169,9 +167,13 @@ public abstract class AbstractValidatorTest<V extends Validator, T>
                 validator.validate(facesContext, getComponent(), item.getTestValue());
                 fail("Validation should have thrown a ValidatorException for testValue" + item);
             } catch (final ValidatorException e) {
-                assertEquals(FacesMessage.SEVERITY_ERROR, e.getFacesMessage().getSeverity());
+                var facesMessage = e.getFacesMessage();
+                assertNotNull(facesMessage,
+                    "ValidatorException carries no FacesMessage but one was expected for test value " + item);
+                assertEquals(item.getSeverity(), facesMessage.getSeverity(),
+                    "The severity does not match the configured test item. TestItem was: " + item);
                 if (null != item.getErrorMessage()) {
-                    assertEquals(item.getErrorMessage(), e.getFacesMessage().getSummary(),
+                    assertEquals(item.getErrorMessage(), facesMessage.getSummary(),
                         "The validation failed as expected, but the messages are not equal as expected");
                 }
             }

--- a/src/test/java/de/cuioss/test/jsf/converter/MessageProducingConverterTest.java
+++ b/src/test/java/de/cuioss/test/jsf/converter/MessageProducingConverterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.jsf.converter;
+
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.convert.Converter;
+import jakarta.faces.convert.ConverterException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Regression test for ASSERT-6 / ASSERT-8: the converter failure loop must verify the
+ * severity and message of the {@link ConverterException}'s {@link FacesMessage} (and
+ * fail meaningfully rather than NPE if it is missing). This converter throws a properly
+ * populated {@link FacesMessage} for the invalid input so the strengthened assertions in
+ * {@link AbstractConverterTest} are exercised.
+ */
+class MessageProducingConverterTest
+    extends AbstractConverterTest<MessageProducingConverterTest.MessageProducingConverter, String> {
+
+    static final String INVALID = "bad";
+    static final String MESSAGE_KEY = "some.converter.KEY";
+
+    @Override
+    public void populate(TestItems<String> testItems) {
+        testItems.addValidString("ok")
+            .addInvalidStringWithMessage(INVALID, MESSAGE_KEY);
+    }
+
+    /** Converter that raises a fully populated {@link ConverterException} for {@link #INVALID}. */
+    public static class MessageProducingConverter implements Converter<String> {
+
+        @Override
+        public String getAsObject(FacesContext context, UIComponent component, String value) {
+            requireNonNull(context);
+            requireNonNull(component);
+            if (INVALID.equals(value)) {
+                throw new ConverterException(
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR, MESSAGE_KEY, MESSAGE_KEY));
+            }
+            return value;
+        }
+
+        @Override
+        public String getAsString(FacesContext context, UIComponent component, String value) {
+            requireNonNull(context);
+            requireNonNull(component);
+            return value == null ? "" : value;
+        }
+    }
+}

--- a/src/test/java/de/cuioss/test/jsf/renderer/CommonRendererAssertsTest.java
+++ b/src/test/java/de/cuioss/test/jsf/renderer/CommonRendererAssertsTest.java
@@ -111,6 +111,22 @@ class CommonRendererAssertsTest {
             "Present passthrough attribute should not trigger an assertion error");
     }
 
+    @Test
+    @DisplayName("RENDERED should pass on empty output but fail on child elements and bare text (ASSERT-4)")
+    void shouldDetectNotRenderedOutput() {
+        var empty = DomUtils.htmlStringToDocument(EMPTY_ELEMENT).getRootElement();
+        assertDoesNotThrow(() -> CommonRendererAsserts.RENDERED.assertAttributeSet(empty),
+            "Empty output must satisfy the not-rendered assertion");
+
+        var withChildren = DomUtils.htmlStringToDocument(NESTED_DIV).getRootElement();
+        assertThrows(AssertionError.class, () -> CommonRendererAsserts.RENDERED.assertAttributeSet(withChildren),
+            "Child elements must fail the not-rendered assertion");
+
+        var textOnly = DomUtils.htmlStringToDocument("plain text output").getRootElement();
+        assertThrows(AssertionError.class, () -> CommonRendererAsserts.RENDERED.assertAttributeSet(textOnly),
+            "Bare text output must fail the not-rendered assertion");
+    }
+
     private static void verifyContract(final RendererAttributeAssert attributeAssert, final String positiveHtml,
         final Serializable traceAttributeValue) {
         var component = new HtmlInputText();

--- a/src/test/java/de/cuioss/test/jsf/renderer/util/DomUtilsTest.java
+++ b/src/test/java/de/cuioss/test/jsf/renderer/util/DomUtilsTest.java
@@ -97,4 +97,15 @@ class DomUtilsTest {
         assertThrows(IllegalArgumentException.class, () -> htmlStringToDocument("<a></b>"),
             "Malformed HTML should raise an IllegalArgumentException");
     }
+
+    @Test
+    @DisplayName("Should reject empty attribute name / value with IllegalArgumentException (ASSERT-10)")
+    void shouldRejectEmptyFilterArguments() {
+        var element = htmlStringToDocument(NESTED_DIV_WITH_STYLE).getRootElement();
+
+        assertThrows(IllegalArgumentException.class, () -> filterForAttribute(element, ""),
+            "An empty attribute name must raise an IllegalArgumentException, not a bare NPE");
+        assertThrows(IllegalArgumentException.class, () -> filterForAttributeContainingValue(element, STYLE, ""),
+            "An empty value fragment must raise an IllegalArgumentException, not a bare NPE");
+    }
 }

--- a/src/test/java/de/cuioss/test/jsf/renderer/util/HtmlTreeAssertsTest.java
+++ b/src/test/java/de/cuioss/test/jsf/renderer/util/HtmlTreeAssertsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("HtmlTreeAsserts")
@@ -90,6 +91,30 @@ class HtmlTreeAssertsTest {
                 HtmlTreeAsserts.assertHtmlTreeEquals(expected, expected);
                 HtmlTreeAsserts.assertHtmlTreeEquals(expected, actual);
             }, "Attribute order should not affect equality");
+        }
+
+        @Test
+        @DisplayName("Should not mutate the attribute order of the argument documents (ASSERT-1)")
+        void shouldNotMutateAttributeOrderOfArguments() {
+            var expected = createDocumentWithDivChild();
+            var actual = createDocumentWithDivChild();
+            // Add attributes in non-sorted order (name before id)
+            var expectedAttributes = expected.getRootElement().getChild(DIV).getAttributes();
+            expectedAttributes.add(createNameAttribute());
+            expectedAttributes.add(createIdAttribute());
+            var actualAttributes = actual.getRootElement().getChild(DIV).getAttributes();
+            actualAttributes.add(createNameAttribute());
+            actualAttributes.add(createIdAttribute());
+
+            HtmlTreeAsserts.assertHtmlTreeEquals(expected, actual);
+
+            // The live attribute list of the argument must retain its original order,
+            // i.e. the comparison must sort copies, not the caller's documents.
+            var afterAttributes = expected.getRootElement().getChild(DIV).getAttributes();
+            assertEquals(NAME, afterAttributes.get(0).getName(),
+                "The comparison must not sort (mutate) the caller's attribute list");
+            assertEquals(ID, afterAttributes.get(1).getName(),
+                "The comparison must not sort (mutate) the caller's attribute list");
         }
 
         @Test


### PR DESCRIPTION
## Cluster 3 — Assertion & test-base robustness (PR-3)

Fixes weaknesses in assertion helpers that mask failures or produce misleading diagnostics, per `doc/review-26-07-04.md`. All findings are minor.

### Findings addressed
| ID | Fix |
|----|-----|
| ASSERT-1 | `HtmlTreeAsserts` copies attribute lists before sorting (no longer mutates reused caller documents) |
| ASSERT-2 | Null asserts run before the first dereference |
| ASSERT-3 | Mixed-content text-position limitation documented |
| ASSERT-4 | `RENDERED` also rejects bare text output; dead null guard removed; `STYLE_CLASS` Javadoc fixed |
| ASSERT-5 | Correct "Expected HTML must not be empty" message; added missing `assertThrows` message; dropped unreachable `throws IOException` |
| ASSERT-6 | Converter/validator failure loops null-check the `FacesMessage` and fail meaningfully instead of NPE |
| ASSERT-7 | `roundtripValues` is a `LinkedHashSet` (deterministic) |
| ASSERT-8 | Failure loops assert the stored severity |
| ASSERT-9 | `AbstractSanitizingConverterTest` asserts a non-null result, with messages |
| ASSERT-10 | `DomUtils` disables DOCTYPE (XXE, S2755); empty input → `IllegalArgumentException` |
| ASSERT-11 | `NavigationAsserts` messages say "null or empty" |
| ASSERT-12 | `Set.of` for `SUPPORTED_TYPES`; `LinkedHashMap` in `ComponentTestHelper`; `new Locale[0]`; removed stale markers; restored `@Typed(ServletContext.class)` |

### Tests
New regression tests for ASSERT-1 (document not mutated), ASSERT-4 (text-only output fails), ASSERT-6/8 (severity & message verified), ASSERT-10 (empty input rejected). Full `./mvnw clean install` green (284 tests); new-code coverage 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y95DNbN4fZHSdaR4wAckzN)_