### PR TITLE
fix(api): deprecate-and-replace misspelled public API (API-1…API-5)

### DIFF
--- a/src/main/java/de/cuioss/test/jsf/component/ComponentPropertyMetadata.java
+++ b/src/main/java/de/cuioss/test/jsf/component/ComponentPropertyMetadata.java
@@ -40,7 +40,17 @@ public class ComponentPropertyMetadata implements PropertyMetadata {
     private final PropertyMetadata delegate;
 
     @Getter
-    private final boolean ignoreOnValueExpresssion;
+    private final boolean ignoreOnValueExpression;
+
+    /**
+     * @return whether the property is ignored for value-expression handling
+     * @deprecated misspelled; use {@link #isIgnoreOnValueExpression()} instead.
+     * Retained for binary compatibility and scheduled for removal in the next major.
+     */
+    @Deprecated
+    public boolean isIgnoreOnValueExpresssion() {
+        return ignoreOnValueExpression;
+    }
 
     /**
      * @see de.cuioss.test.valueobjects.property.PropertyMetadata#getName()

--- a/src/main/java/de/cuioss/test/jsf/component/ValueExpressionPropertyContract.java
+++ b/src/main/java/de/cuioss/test/jsf/component/ValueExpressionPropertyContract.java
@@ -64,7 +64,7 @@ public class ValueExpressionPropertyContract<T extends UIComponent> implements T
     public ValueExpressionPropertyContract(final ParameterizedInstantiator<T> instantiator,
         final List<ComponentPropertyMetadata> metadata, final FacesContext facesContext) {
         this.instantiator = instantiator;
-        filteredMetadata = metadata.stream().filter(m -> !m.isIgnoreOnValueExpresssion()).toList();
+        filteredMetadata = metadata.stream().filter(m -> !m.isIgnoreOnValueExpression()).toList();
         this.facesContext = facesContext;
     }
 

--- a/src/main/java/de/cuioss/test/jsf/config/JsfTestContextConfigurator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/JsfTestContextConfigurator.java
@@ -16,12 +16,15 @@
 package de.cuioss.test.jsf.config;
 
 /**
- * Simple Marker Interface for grouping the different JSf test configurators
- * like {@link ApplicationConfigurator},{@link ComponentConfigurator} and {@link RequestConfigurator}
+ * Obsolete marker interface. It is <em>not</em> implemented or extended by any of the
+ * configurator interfaces ({@link ApplicationConfigurator}, {@link ComponentConfigurator}
+ * and {@link RequestConfigurator}) — those extend {@link JsfTestSetup} instead. It is
+ * retained only for binary compatibility.
  *
  * @author Oliver Wolff
- * @deprecated As of 1.0.0, all sub-interfaces are deprecated in favor of the parameter resolution approach.
- * See the migration guide for more details on how to migrate to the parameter resolution approach.
+ * @deprecated As of 1.0.0, superseded by {@link JsfTestSetup} and the parameter-resolution
+ * approach; scheduled for removal in the next major. See the migration guide for more
+ * details on how to migrate.
  */
 @Deprecated
 public interface JsfTestContextConfigurator {

--- a/src/main/java/de/cuioss/test/jsf/generator/ConverterDescriptor.java
+++ b/src/main/java/de/cuioss/test/jsf/generator/ConverterDescriptor.java
@@ -30,7 +30,7 @@ import lombok.ToString;
 @RequiredArgsConstructor
 @EqualsAndHashCode
 @ToString
-class ConverterDescriptor {
+public class ConverterDescriptor {
 
     @Getter
     private final Class<? extends Converter> converterClass;

--- a/src/main/java/de/cuioss/test/jsf/generator/JsfProvidedConverter.java
+++ b/src/main/java/de/cuioss/test/jsf/generator/JsfProvidedConverter.java
@@ -17,7 +17,6 @@ package de.cuioss.test.jsf.generator;
 
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.TypedGenerator;
-import de.cuioss.test.jsf.config.ComponentConfigurator;
 import jakarta.faces.convert.*;
 
 import java.math.BigDecimal;
@@ -28,8 +27,9 @@ import java.util.List;
 import static de.cuioss.tools.collect.CollectionLiterals.immutableList;
 
 /**
- * Hybrid class that acts as an {@link TypedGenerator} and
- * {@link ComponentConfigurator}.
+ * A {@link TypedGenerator} providing the converter classes shipped with JSF. The
+ * available descriptors are exposed via {@link #JSF_CONVERTER} and the accompanying
+ * generators.
  *
  * @author Oliver Wolff
  */
@@ -58,8 +58,17 @@ public class JsfProvidedConverter implements TypedGenerator<Class> {
     /**
      * Defines a generator for all converter types provided by JSF.
      */
-    public static final TypedGenerator<ConverterDescriptor> CONVERTER_CLASS_GERNERATOR = Generators
+    public static final TypedGenerator<ConverterDescriptor> CONVERTER_CLASS_GENERATOR = Generators
         .fixedValues(JSF_CONVERTER);
+
+    /**
+     * Defines a generator for all converter types provided by JSF.
+     *
+     * @deprecated misspelled; use {@link #CONVERTER_CLASS_GENERATOR}. Retained for one
+     * release and scheduled for removal in the next major.
+     */
+    @Deprecated
+    public static final TypedGenerator<ConverterDescriptor> CONVERTER_CLASS_GERNERATOR = CONVERTER_CLASS_GENERATOR;
 
     /**
      * A generator for every id of registered generator.
@@ -76,7 +85,7 @@ public class JsfProvidedConverter implements TypedGenerator<Class> {
     @SuppressWarnings("unchecked")
     @Override
     public Class<Converter> next() {
-        return (Class<Converter>) CONVERTER_CLASS_GERNERATOR.next().getConverterClass();
+        return (Class<Converter>) CONVERTER_CLASS_GENERATOR.next().getConverterClass();
     }
 
     @Override

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandler.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandler.java
@@ -52,12 +52,12 @@ public class CuiMockResourceHandler extends ResourceHandler {
     public static final String RESOURCE_NOT_THERE = "resNotThere";
 
     /**
-     * "rendererererer"
+     * "-rendererererer"
      */
     public static final String RENDERER_SUFFIX = "-rendererererer";
 
     /**
-     * the availableResouces use the form libraryName + LIBRARY_RESOURCE_DELIMITER +
+     * the availableResources use the form libraryName + LIBRARY_RESOURCE_DELIMITER +
      * resourceName as key
      */
     public static final String LIBRARY_RESOURCE_DELIMITER = "-";
@@ -75,10 +75,30 @@ public class CuiMockResourceHandler extends ResourceHandler {
      */
     @Getter
     @Setter
-    private Map<String, CuiMockResource> availableResouces = new HashMap<>();
+    private Map<String, CuiMockResource> availableResources = new HashMap<>();
 
     /**
-     * Creates an resourceIdetnifier utilized by availableResouces
+     * @return the configured resources
+     * @deprecated misspelled; use {@link #getAvailableResources()} instead. Retained
+     * for binary compatibility and scheduled for removal in the next major.
+     */
+    @Deprecated
+    public Map<String, CuiMockResource> getAvailableResouces() {
+        return availableResources;
+    }
+
+    /**
+     * @param availableResources the resources to configure
+     * @deprecated misspelled; use {@link #setAvailableResources(Map)} instead. Retained
+     * for binary compatibility and scheduled for removal in the next major.
+     */
+    @Deprecated
+    public void setAvailableResouces(final Map<String, CuiMockResource> availableResources) {
+        this.availableResources = availableResources;
+    }
+
+    /**
+     * Creates a resourceIdentifier utilized by availableResources
      *
      * @param resourceName may be null
      * @param libraryName  may be null
@@ -108,7 +128,7 @@ public class CuiMockResourceHandler extends ResourceHandler {
 
     @Override
     public Resource createResource(final String resourceName, final String libraryName, final String contentType) {
-        return availableResouces.get(createResourceMapKey(resourceName, libraryName));
+        return availableResources.get(createResourceMapKey(resourceName, libraryName));
     }
 
     @Override

--- a/src/main/java/de/cuioss/test/jsf/mocks/ReverseConverter.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/ReverseConverter.java
@@ -36,7 +36,16 @@ public class ReverseConverter implements Converter<String> {
      * The standard converter id for this converter.
      * </p>
      */
-    public static final String CONVERTER_ID = "de.cuioss.test.jsf.mocks.ReserveConverter";
+    public static final String CONVERTER_ID = "de.cuioss.test.jsf.mocks.ReverseConverter";
+
+    /**
+     * The previous, misspelled converter id ("Reserve" instead of "Reverse").
+     *
+     * @deprecated use {@link #CONVERTER_ID}. Retained for one release for consumers
+     * that still reference the old id; scheduled for removal in the next major.
+     */
+    @Deprecated
+    public static final String RESERVE_CONVERTER_ID = "de.cuioss.test.jsf.mocks.ReserveConverter";
 
     @Override
     public String getAsObject(final FacesContext context, final UIComponent component, final String value) {

--- a/src/test/java/de/cuioss/test/jsf/component/ComponentPropertyMetadataTest.java
+++ b/src/test/java/de/cuioss/test/jsf/component/ComponentPropertyMetadataTest.java
@@ -26,11 +26,15 @@ import de.cuioss.test.valueobjects.api.property.PropertyReflectionConfig;
 import de.cuioss.test.valueobjects.property.PropertyMetadata;
 import de.cuioss.test.valueobjects.property.impl.PropertyMetadataImpl;
 import de.cuioss.tools.property.PropertyReadWrite;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @PropertyReflectionConfig(skip = true)
 @PropertyConfig(name = "delegate", propertyClass = PropertyMetadata.class, required = true, propertyReadWrite = PropertyReadWrite.WRITE_ONLY)
-@PropertyConfig(name = "ignoreOnValueExpresssion", propertyClass = boolean.class)
-@VerifyConstructor(of = {"delegate", "ignoreOnValueExpresssion"})
+@PropertyConfig(name = "ignoreOnValueExpression", propertyClass = boolean.class)
+@VerifyConstructor(of = {"delegate", "ignoreOnValueExpression"})
 @VetoObjectTestContract(ObjectTestContracts.SERIALIZABLE)
 class ComponentPropertyMetadataTest extends ValueObjectTest<ComponentPropertyMetadata>
     implements TypedGenerator<PropertyMetadata> {
@@ -44,6 +48,16 @@ class ComponentPropertyMetadataTest extends ValueObjectTest<ComponentPropertyMet
     @Override
     public Class<PropertyMetadata> getType() {
         return PropertyMetadata.class;
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecatedGetterMatchesCorrectlySpelledGetter() {
+        var metadata = new ComponentPropertyMetadata(next(), true);
+
+        assertTrue(metadata.isIgnoreOnValueExpression(), "The correctly-spelled getter must return the value");
+        assertEquals(metadata.isIgnoreOnValueExpression(), metadata.isIgnoreOnValueExpresssion(),
+            "The deprecated getter must match the correctly-spelled one (API-1)");
     }
 
 }

--- a/src/test/java/de/cuioss/test/jsf/generator/JsfProvidedConverterTest.java
+++ b/src/test/java/de/cuioss/test/jsf/generator/JsfProvidedConverterTest.java
@@ -48,7 +48,7 @@ class JsfProvidedConverterTest {
     @DisplayName("Should generate non-null values for all converter-specific generators")
     void shouldGenerateConverterSpecificTypes() {
         assertNotNull(new JsfProvidedConverter().next(), "Hybrid generator should produce a converter class");
-        assertNotNull(JsfProvidedConverter.CONVERTER_CLASS_GERNERATOR.next(),
+        assertNotNull(JsfProvidedConverter.CONVERTER_CLASS_GENERATOR.next(),
             "Converter-class generator should produce a descriptor");
         assertNotNull(JsfProvidedConverter.CONVERTER_ID_GENERATOR.next(),
             "Converter-id generator should produce an id");

--- a/src/test/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandlerTest.java
+++ b/src/test/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandlerTest.java
@@ -18,10 +18,39 @@ package de.cuioss.test.jsf.mocks;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("CuiMockResourceHandler")
 class CuiMockResourceHandlerTest {
+
+    @Test
+    @DisplayName("Deprecated availableResouces accessors delegate to the correctly-spelled ones (API-2)")
+    @SuppressWarnings("deprecation")
+    void deprecatedAvailableResourcesAccessorsDelegate() {
+        var handler = new CuiMockResourceHandler();
+        var map = new HashMap<String, CuiMockResource>();
+
+        handler.setAvailableResouces(map);
+
+        assertSame(map, handler.getAvailableResources(), "The correctly-spelled getter must return the set map");
+        assertSame(map, handler.getAvailableResouces(), "The deprecated getter must delegate to the same map");
+    }
+
+    @Test
+    @DisplayName("createResource resolves against the configured resources map")
+    void shouldResolveResourceFromMap() {
+        var handler = new CuiMockResourceHandler();
+
+        assertNull(handler.createResource("res", "lib"),
+            "An unregistered resource must resolve to null");
+
+        var resource = new CuiMockResource();
+        handler.getAvailableResources().put(CuiMockResourceHandler.createResourceMapKey("res", "lib"), resource);
+        assertSame(resource, handler.createResource("res", "lib"),
+            "A registered resource must be resolved from the map");
+    }
 
     @Test
     @DisplayName("Should derive the resource map key from name and library")


### PR DESCRIPTION
## Cluster 4 — Public-API naming, deprecation path (PR-4)

Fixes misspelled/inaccurate published API via **deprecate-and-replace** — nothing is removed in this release. Per `doc/review-26-07-04.md`.

### Findings addressed
| ID | Fix |
|----|-----|
| API-1 | `ComponentPropertyMetadata` field → `ignoreOnValueExpression`; deprecated bridge `isIgnoreOnValueExpresssion()` retained |
| API-2 | `CuiMockResourceHandler` field → `availableResources` with deprecated `get/setAvailableResouces` bridges; Javadoc/constant typos fixed |
| API-3 | `ReverseConverter.CONVERTER_ID` corrected to `…ReverseConverter`; old value kept in deprecated `RESERVE_CONVERTER_ID` |
| API-4 | `JsfProvidedConverter` Javadoc corrected (it only implements `TypedGenerator`); `ConverterDescriptor` made public; `CONVERTER_CLASS_GENERATOR` added, `CONVERTER_CLASS_GERNERATOR` deprecated |
| API-5 | `JsfTestContextConfigurator` Javadoc corrected — nothing implements it; superseded by `JsfTestSetup` |

### Tests
Added coverage for the deprecated bridge accessors. Full `./mvnw clean install` green (286 tests); new-code coverage ≈ 100%. Deprecated bridges keep the old signatures for binary compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y95DNbN4fZHSdaR4wAckzN)_