### PR TITLE
fix(build): correct dependencies, dependabot & CI workflows (BUILD-1…BUILD-9)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
       semver-major-days: 7
       semver-minor-days: 3
       semver-patch-days: 1
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   auto-merge:
+    if: github.actor == 'dependabot[bot]'
     uses: cuioss/cuioss-organization/.github/workflows/reusable-dependabot-auto-merge.yml@0af17b4211b2db37c3bc9b5f316f0c534c3ee8d5 # v0.6.8
     permissions:
       contents: write

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,7 +4,7 @@ name: Maven Build
 
 on:
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
+    branches: [main, "feature/*", "fix/*", "chore/*", "release/*"]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: read
   pull-requests: read
+
+# Avoid duplicate/stale runs for the same ref (e.g. Dependabot push + PR)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,6 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.websocket</groupId>
-            <artifactId>jakarta.websocket-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
         </dependency>
@@ -83,6 +75,11 @@
             <artifactId>jdom2</artifactId>
         </dependency>
         <dependency>
+            <groupId>de.cuioss</groupId>
+            <artifactId>cui-java-tools</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.myfaces.core</groupId>
             <artifactId>myfaces-test</artifactId>
             <scope>compile</scope>
@@ -98,13 +95,15 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>de.cuioss.test</groupId>
-            <artifactId>cui-test-value-objects</artifactId>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
+            <version>6.0.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.cuioss.test</groupId>
-            <artifactId>cui-test-juli-logger</artifactId>
+            <artifactId>cui-test-value-objects</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.cuioss.test</groupId>


### PR DESCRIPTION
## Cluster 5 — Build, dependencies & CI (PR-5)

Per `doc/review-26-07-04.md`.

### Findings addressed
| ID | Fix |
|----|-----|
| BUILD-1 [M] | Declare the used-but-undeclared `de.cuioss:cui-java-tools` |
| BUILD-2 | Remove unused `jakarta.websocket-api` |
| BUILD-3 | Remove unused `jakarta.validation-api` |
| BUILD-4 | Remove unused `cui-test-juli-logger` |
| BUILD-5 | Declare the used-but-undeclared `junit-platform-commons` (version pinned to `6.0.3` — not managed by an imported BOM) |
| BUILD-6 | Add a `github-actions` ecosystem to Dependabot |
| BUILD-7 | Drop `dependabot/**` from the Maven push triggers; add a `concurrency` group |
| BUILD-8 | Guard the Dependabot auto-merge job with `github.actor == 'dependabot[bot]'` |
| BUILD-9 | Bump the Maven wrapper distribution to `3.9.11` |

BUILD-10 (stale `CLAUDE.md` metadata) is handled with the docs cluster (PR-7) to avoid a double edit.

### Verification
`./mvnw clean install dependency:analyze` green (287 tests); **no more "used but undeclared" dependencies**. Two residual `dependency:analyze` warnings are intentionally left: `easymock` (compile-scoped, offered to consumers; its internal use was removed in PR-1) and the `junit-jupiter` aggregator (test-engine, a standard false positive). Neither is gated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y95DNbN4fZHSdaR4wAckzN)_