### PR TITLE
docs: update documentation & Javadoc to the post-fix state (DOC-1…DOC-15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-cui-jsf-test-basic is a JSF testing framework that extends MyFaces-Test with mock-based infrastructure for testing JSF components, validators, converters, and renderers in Jakarta EE 10 (JSF 4.1+) environments. It provides base test classes, HTML tree generation/assertion tools, and JUnit 5 integration.
+cui-jsf-test-basic is a JSF testing framework that extends MyFaces-Test with mock-based infrastructure for testing JSF components, validators, converters, and renderers on Jakarta Faces 4.1 (Jakarta EE 11). It provides base test classes, HTML-tree assertion tooling, and JUnit 5 integration.
 
 ## Logging Standards for This Project
 
@@ -24,8 +24,8 @@ Do not create LogRecord constants or migrate to structured logging for this libr
 ## Build Commands
 
 ```bash
-# Build and install (default - includes rewrite profile)
-./mvnw -Prewrite clean install
+# Build and install (includes the pre-commit profile)
+./mvnw -Ppre-commit clean install
 
 # Run all tests
 ./mvnw test
@@ -44,8 +44,8 @@ Do not create LogRecord constants or migrate to structured logging for this libr
 # Review console output and fix all reported issues
 
 # Run code cleanup with rewrite only (without full build)
-./mvnw -Prewrite rewrite:run
-./mvnw -Prewrite clean install  # Verify changes
+./mvnw -Ppre-commit rewrite:run
+./mvnw -Ppre-commit clean install  # Verify changes
 ```
 
 
@@ -74,6 +74,7 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
   - `@EnableJsfEnvironment`: Main annotation to enable JSF test context
   - `JsfSetupExtension`: Extension that manages JSF lifecycle
   - `JsfParameterResolver`: Resolves JSF objects as test method parameters
+  - `NavigationAsserts`: Assertions for navigation outcomes and redirects (`de.cuioss.test.jsf.junit5.NavigationAsserts`)
 
 - **component/**: Component testing infrastructure
   - `AbstractComponentTest<T>`: Base for testing JSF component classes
@@ -90,7 +91,6 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 
 - **renderer/**: Renderer testing utilities
   - `AbstractComponentRendererTest<R>`: Base for renderer tests
-  - `HtmlTreeBuilder`: Programmatic HTML tree construction
   - `HtmlTreeAsserts`: Assertions for rendered HTML output
 
 - **config/**: Configuration infrastructure
@@ -105,7 +105,6 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 
 - **util/**: Utility classes
   - `JsfEnvironmentHolder`: Container for JSF test environment
-  - `NavigationAsserts`: Assertions for navigation outcomes and redirects
 
 ### Package Structure
 ```
@@ -214,16 +213,13 @@ class MyComponentTest extends AbstractComponentTest<MyComponent> {
 class MyRendererTest extends AbstractComponentRendererTest<MyRenderer> {
 
     @Test
-    void shouldRenderMinimal(ComponentConfigDecorator componentConfig) {
+    void shouldRenderMinimal(FacesContext facesContext, ComponentConfigDecorator componentConfig) {
         componentConfig.registerUIComponent(MyComponent.class);
 
         UIComponent component = getComponent();
-        HtmlTreeBuilder expected = new HtmlTreeBuilder()
-            .withNode(Node.DIV)
-            .withAttributeNameAndId("componentId")
-            .withAttribute(AttributeName.CLASS, "my-class");
+        String expectedHtml = "<div id=\"componentId\" name=\"componentId\" class=\"my-class\"></div>";
 
-        assertRenderResult(component, expected.getDocument());
+        assertRenderResult(component, expectedHtml, facesContext);
     }
 
     @Override
@@ -278,7 +274,7 @@ To disable: `@EnableJsfEnvironment(useIdentityResourceBundle = false)`
 
 ## Important Dependencies
 
-- **Jakarta EE 10** (JSF 4.1+)
+- **Jakarta Faces 4.1** (Jakarta EE 11)
 - **MyFaces Test** - Must use `myfaces-api` (not Mojarra) due to classloader issues in parallel execution
 - **JUnit 5** - All tests use JUnit Jupiter
 - **Lombok** - Used throughout for builders, value objects, etc.
@@ -290,24 +286,24 @@ To disable: `@EnableJsfEnvironment(useIdentityResourceBundle = false)`
 
 **Deprecated approaches:**
 - `JsfEnvironmentConsumer` interface - Use parameter resolution instead
-- `JsfEnabledTestEnvironment` base class - Use parameter resolution instead
+- `JsfEnabledTestEnvironment` base class — removed in 4.x; use parameter resolution instead
 - Configurator interfaces (`ApplicationConfigurator`, `ComponentConfigurator`, `RequestConfigurator`) - Use decorator parameters instead
 
-See `doc/migration.adoc` for detailed migration guide.
+See `doc/migration/4.1.adoc` and `doc/migration/4.3.adoc` for detailed migration guides.
 
 ## Documentation References
 
 - Usage guide: `doc/usage.adoc`
-- Migration guide: `doc/migration.adoc`
+- Migration guides: `doc/migration/4.1.adoc`, `doc/migration/4.3.adoc`
 - Generated docs: https://cuioss.github.io/cui-jsf-test-basic/about.html
 - MyFaces Test: http://myfaces.apache.org/test/index.html
 
 ## Version Information
 
-- Current version: 4.0-SNAPSHOT
+- Current version: 4.4-SNAPSHOT
 - JSF 4+ support: main branch (4.x releases)
-- JSF 2.3 support: Release 2.0.2 on v2 branch
-- Parent POM: `de.cuioss:cui-java-parent:0.9.9.6`
+- JSF 2.3 support: Release 2.0.2 on `release/v2` branch
+- Parent POM: `de.cuioss:cui-java-parent:1.4.5`
 
 ## Temporary Files
 

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ Extension for http://myfaces.apache.org/test/index.html[MyFaces-Test] that uses 
 ** `AbstractComponentTest`
 ** `AbstractUiComponentTest`
 ** `AbstractComponentRendererTest`
-* Tooling for generating (partial-)HTML-trees including the corresponding Assertions
+* HTML-tree assertion tooling for verifying (partial-)HTML-trees
 * Additional Mocks completing the ones provided from myfaces-test
 * Integration into https://github.com/cuioss/cui-test-value-objects[cui-test-value-objects] framework
 * Baseline is JSF 4.1

--- a/doc/migration/4.1.adoc
+++ b/doc/migration/4.1.adoc
@@ -39,7 +39,7 @@ Ensure you're using the latest version of the JSF testing framework that include
 
 === Step 2: Identify Classes Using JsfEnvironmentConsumer
 
-Identify test classes that currently implement `JsfEnvironmentConsumer` or extend `JsfEnabledTestEnvironment`. These classes will need to be migrated.
+Identify test classes that currently implement `JsfEnvironmentConsumer` or that extended the now-removed `JsfEnabledTestEnvironment` base class. These classes will need to be migrated. Note that `JsfEnabledTestEnvironment` has been removed in 4.x, so it can no longer be extended.
 
 === Step 3: Migrate Test Methods
 
@@ -86,7 +86,7 @@ class MyTest {
 
 === Step 4: Migrate Base Classes
 
-If your test classes extend `JsfEnabledTestEnvironment`, consider migrating to a standalone test class that uses parameter resolution.
+If your test classes still extended the now-removed `JsfEnabledTestEnvironment`, migrate them to a standalone test class that uses parameter resolution. The class no longer exists in 4.x, so extending it is no longer possible.
 
 ==== Before Migration
 
@@ -153,7 +153,7 @@ class MyComponentTest implements ComponentConfigurator {
 
     @Override
     public void configureComponents(ComponentConfigDecorator decorator) {
-        decorator.registerMockRenderer("javax.faces.Output", "javax.faces.Text");
+        decorator.registerMockRenderer("jakarta.faces.Output", "jakarta.faces.Text");
     }
 }
 ----
@@ -167,7 +167,7 @@ class MyComponentTest {
 
     @Test
     void testComponent(ComponentConfigDecorator componentConfig) {
-        componentConfig.registerMockRenderer("javax.faces.Output", "javax.faces.Text");
+        componentConfig.registerMockRenderer("jakarta.faces.Output", "jakarta.faces.Text");
 
         // Test code
     }
@@ -187,7 +187,7 @@ This approach has several advantages:
 
 === Step 6: Update Utility Method Calls
 
-If your tests use utility methods from `JsfEnvironmentConsumer` or `JsfEnabledTestEnvironment`, update them to use the `NavigationAsserts` parameter type.
+If your tests used utility methods from `JsfEnvironmentConsumer` or the now-removed `JsfEnabledTestEnvironment`, update them to use the `NavigationAsserts` parameter type.
 
 *Old approach (JsfEnvironmentConsumer):*
 
@@ -244,7 +244,7 @@ void testWithMultipleParameters(
 @Test
 void testComponentConfiguration(ComponentConfigDecorator componentConfig) {
     // Register a mock component
-    componentConfig.registerMockRenderer("javax.faces.Output", "javax.faces.Text");
+    componentConfig.registerMockRenderer("jakarta.faces.Output", "jakarta.faces.Text");
 
     // Test code using the configured component
 }

--- a/doc/usage.adoc
+++ b/doc/usage.adoc
@@ -10,10 +10,10 @@ Extension for http://myfaces.apache.org/test/index.html[MyFaces-Test] that uses 
 ** `AbstractComponentTest`
 ** `AbstractUiComponentTest`
 ** `AbstractComponentRendererTest`
-* Tooling for generating (partial-)HTML-trees including the corresponding Assertions
+* HTML-tree assertion tooling for verifying (partial-)HTML-trees
 * Additional Mocks completing the ones provided from myfaces-test
 * Integration into https://github.com/cuioss/cui-test-value-objects[cui-test-value-objects] framework
-* Baseline is Jakarta Faces (part of Jakarta EE 10)
+* Baseline is Jakarta Faces 4.1 (part of Jakarta EE 11)
 
 == How To use it
 
@@ -104,7 +104,7 @@ The following decorator types are available for configuration:
 * `de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator`
 * `de.cuioss.test.jsf.config.decorator.RequestConfigDecorator`
 
-For details on how to migrate from the deprecated callback interfaces to the parameter resolution approach, see the link:migration.adoc[Migration Guide].
+For details on how to migrate from the deprecated callback interfaces to the parameter resolution approach, see the link:migration/4.1.adoc[Migration Guide (4.1)] and link:migration/4.3.adoc[Migration Guide (4.3)].
 
 
 === Parameter Resolution (Recommended Approach)
@@ -184,7 +184,7 @@ class NavigationTest {
 }
 ----
 
-For more detailed information about parameter resolution, including common patterns, examples, and migration from deprecated approaches, see the link:migration.adoc[Migration Guide].
+For more detailed information about parameter resolution, including common patterns, examples, and migration from deprecated approaches, see the link:migration/4.1.adoc[Migration Guide (4.1)] and link:migration/4.3.adoc[Migration Guide (4.3)].
 
 
 == Testing a Validator
@@ -209,7 +209,7 @@ class AbstractValidatorTestTest extends AbstractValidatorTest<LengthValidator, S
 }
 ----
 
-Take a closer look at the parameter addInvalidWithMessage. It passes and checks the key not a resolved message, see `de.cuioss.test.jsf.junit5.EnableJsfEnvironment#useIdentityResouceBundle` for an explanation of the resource-bundle handling.
+Take a closer look at the parameter addInvalidWithMessage. It passes and checks the key not a resolved message, see `de.cuioss.test.jsf.junit5.EnableJsfEnvironment#useIdentityResourceBundle` for an explanation of the resource-bundle handling.
 
 === Testing a Converter
 
@@ -289,18 +289,12 @@ This is a complex real-world-example bringing together many aspects of the test-
 ----
 
 @JsfTestConfiguration(CoreJsfTestConfiguration.class)
-class SwitchRendererTest extends AbstractComponentRendererTest<SwitchRenderer> implements ComponentConfigurator {
-
-    @Override
-    public void configureComponents(final ComponentConfigDecorator decorator) {
-        decorator.registerUIComponent(ColumnComponent.class).
-        registerRenderer(LayoutComponentRenderer.class);
-   }
+class SwitchRendererTest extends AbstractComponentRendererTest<SwitchRenderer> {
 
     @Override
     protected UIComponent getComponent() {
         final SwitchComponent component = new SwitchComponent();
-        component.setId(testComponent);
+        component.setId("testComponent");
         component.setTitleValue(titleValue);
         component.setTitleKey(titleKey);
         component.setOnTextValue(onText);
@@ -314,89 +308,49 @@ class SwitchRendererTest extends AbstractComponentRendererTest<SwitchRenderer> i
     }
 
    @Test
-   void shouldRenderMinimal() {
+   void shouldRenderMinimal(FacesContext facesContext, ComponentConfigDecorator componentConfig) {
+       componentConfig.registerUIComponent(ColumnComponent.class)
+               .registerRenderer(LayoutComponentRenderer.class);
+
        final SwitchComponent component = (SwitchComponent) getComponent();
        component.processEvent(new PostAddToViewEvent(component));
        component.processEvent(new PreRenderComponentEvent(component));
 
-       final HtmlTreeBuilder expected = buildHtmlTree(false, false);
-       assertRenderResult(component, expected.getDocument());
+       assertRenderResult(component, expectedHtml(false), facesContext);
    }
 
    @Test
-   void shouldRenderDisabled() {
+   void shouldRenderDisabled(FacesContext facesContext, ComponentConfigDecorator componentConfig) {
+       componentConfig.registerUIComponent(ColumnComponent.class)
+               .registerRenderer(LayoutComponentRenderer.class);
+
        final SwitchComponent component = (SwitchComponent) getComponent();
        component.setDisabled(true);
 
        component.processEvent(new PostAddToViewEvent(component));
        component.processEvent(new PreRenderComponentEvent(component));
 
-       final HtmlTreeBuilder expected = buildHtmlTree(false, true);
-       assertRenderResult(component, expected.getDocument());
+       assertRenderResult(component, expectedHtml(true), facesContext);
    }
+
    /**
-    * <div id="testComponent_container"
-    * name="testComponent_container"
-    * data-switch-disabled="true|false">
-    * <div class="col-sm-6 switch-placing">
-    * <label class="switch">
-    * <input id="testComponent" name="testComponent"/>
-    * <span class="slider round"/>
-    * </label>
-    * <span class="switch-text" data-item-active="true">onText</span>
-    * <span class="switch-text" data-item-active="false">offText</span>
-    * </div>
-    * </div>
+    * The expected HTML is provided as a plain String. It is parsed via
+    * {@code DomUtils#htmlStringToDocument(String)} before being compared to the
+    * rendered output by {@code assertRenderResult}.
     */
-   private HtmlTreeBuilder buildHtmlTree(final boolean isActive, final boolean isDisabled) {
-     final HtmlTreeBuilder expected = new HtmlTreeBuilder()
-     // container
-     .withNode(Node.DIV)
-     .withAttributeNameAndId("testComponent_container")
-     .withAttribute("data-switch-disabled", String.valueOf(isDisabled))
-     .withAttribute(AttributeName.CLASS, styleClass)
-     .withAttribute(AttributeName.STYLE, style)
-
-     // column
-     .withNode(Node.DIV)
-     .withAttribute(AttributeName.CLASS, default_column_size + " switch-placing")
-
-     // label
-     .withNode(Node.LABEL)
-     .withAttribute(AttributeName.CLASS, "switch")
-     .withAttribute(AttributeName.TITLE, titleValue)
-
-     // checkbox
-     .withNode(Node.INPUT)
-     .withAttributeNameAndId("testComponent")
-     .currentHierarchyUp()
-
-     // slider
-     .withNode(Node.SPAN)
-     .withAttribute(AttributeName.CLASS, "slider round")
-     .currentHierarchyUp()
-
-     // leaving label
-     .currentHierarchyUp()
-
-     // on text
-     .withNode(Node.SPAN)
-     .withAttribute(AttributeName.CLASS, "switch-text" + (!isActive ? " hidden" : ""))
-     .withAttribute(AttributeName.DATA_ITEM_ACTIVE, "true")
-     .withTextContent(onText)
-     .currentHierarchyUp()
-
-     // off text
-     .withNode(Node.SPAN)
-     .withAttribute(AttributeName.CLASS, "switch-text" + (isActive ? " hidden" : ""))
-     .withAttribute(AttributeName.DATA_ITEM_ACTIVE, "false")
-     .withTextContent(offText)
-     .currentHierarchyUp()
-
-     // leaving column
-     .currentHierarchyUp();
-
-      return expected;
-    }
+   private String expectedHtml(final boolean isDisabled) {
+       return "<div id=\"testComponent_container\" name=\"testComponent_container\""
+               + " data-switch-disabled=\"" + isDisabled + "\""
+               + " class=\"" + styleClass + "\" style=\"" + style + "\">"
+               + "<div class=\"col-sm-6 switch-placing\">"
+               + "<label class=\"switch\" title=\"" + titleValue + "\">"
+               + "<input id=\"testComponent\" name=\"testComponent\"/>"
+               + "<span class=\"slider round\"></span>"
+               + "</label>"
+               + "<span class=\"switch-text\" data-item-active=\"true\">" + onText + "</span>"
+               + "<span class=\"switch-text hidden\" data-item-active=\"false\">" + offText + "</span>"
+               + "</div>"
+               + "</div>";
+   }
 }
 ----

--- a/src/main/java/de/cuioss/test/jsf/component/ComponentPropertyMetadata.java
+++ b/src/main/java/de/cuioss/test/jsf/component/ComponentPropertyMetadata.java
@@ -44,7 +44,7 @@ public class ComponentPropertyMetadata implements PropertyMetadata {
 
     /**
      * @return whether the property is ignored for value-expression handling
-     * @deprecated misspelled; use {@link #isIgnoreOnValueExpression()} instead.
+     * @deprecated misspelled; use {@code isIgnoreOnValueExpression()} instead.
      * Retained for binary compatibility and scheduled for removal in the next major.
      */
     @Deprecated

--- a/src/main/java/de/cuioss/test/jsf/component/ValueExpressionPropertyContract.java
+++ b/src/main/java/de/cuioss/test/jsf/component/ValueExpressionPropertyContract.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  * Tests all given properties according to the given List of
  * {@link ComponentPropertyMetadata}
  *
- * @param <T> The Rule does not apply to annotations: There is no inheritance
+ * @param <T> the concrete {@link UIComponent} type whose properties are verified
  * @author Oliver Wolff
  */
 // cui-rewrite:disable CuiLogRecordPatternRecipe
@@ -57,9 +57,11 @@ public class ValueExpressionPropertyContract<T extends UIComponent> implements T
     private final FacesContext facesContext;
 
     /**
-     * @param instantiator
-     * @param metadata
-     * @param facesContext
+     * @param instantiator used for creating instances of the component under test
+     * @param metadata     the property metadata describing the component
+     *                     properties to be verified via value-expressions
+     * @param facesContext the {@link FacesContext} used for evaluating the
+     *                     value-expressions
      */
     public ValueExpressionPropertyContract(final ParameterizedInstantiator<T> instantiator,
         final List<ComponentPropertyMetadata> metadata, final FacesContext facesContext) {

--- a/src/main/java/de/cuioss/test/jsf/component/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/component/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides base-classes and contracts for conveniently testing JSF
+ * {@link jakarta.faces.component.UIComponent}s, including declarative property
+ * and value-expression verification.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.component;

--- a/src/main/java/de/cuioss/test/jsf/config/ComponentConfigurator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/ComponentConfigurator.java
@@ -30,7 +30,7 @@ import de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator;
  * @Test
  * void testComponentConfiguration(ComponentConfigDecorator componentConfig) {
  *     // Register a mock component
- *     componentConfig.registerMockRenderer("javax.faces.Output", "javax.faces.Text");
+ *     componentConfig.registerMockRenderer("jakarta.faces.Output", "jakarta.faces.Text");
  *
  *     // Test code using the configured component
  * }

--- a/src/main/java/de/cuioss/test/jsf/config/component/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/config/component/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides annotations and support types for component-specific test
+ * configuration.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.config.component;

--- a/src/main/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecorator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/decorator/ApplicationConfigDecorator.java
@@ -34,8 +34,10 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 /**
- * Helper class acting as runtime-registry for {@link ResourceBundle},
- * {@link NavigationHandler},
+ * Helper class acting as runtime-registry for {@link ResourceBundle}s,
+ * {@link NavigationHandler} configuration, supported and default {@link Locale}s,
+ * the {@link ProjectStage} and further application-level settings used within
+ * JSF tests.
  *
  * @author Oliver Wolff
  */
@@ -159,7 +161,8 @@ public class ApplicationConfigDecorator {
     public ApplicationConfigDecorator setProjectStage(final ProjectStage projectStage) {
         var projectStageField = FieldWrapper.from(MockApplication20.class, "_projectStage");
         if (projectStageField.isEmpty()) {
-            throw new IllegalStateException("Unable to set projectStage, due to underlying Exception");
+            throw new IllegalStateException(
+                "Unable to set projectStage: the '_projectStage' field could not be found on MockApplication20");
         }
         projectStageField.get().writeValue(getMockApplicationInstance(application), projectStage);
         return this;

--- a/src/main/java/de/cuioss/test/jsf/config/decorator/ComponentConfigDecorator.java
+++ b/src/main/java/de/cuioss/test/jsf/config/decorator/ComponentConfigDecorator.java
@@ -61,7 +61,7 @@ public class ComponentConfigDecorator {
     private static final String TARGET_CLASS_MUST_NOT_BE_NULL = "targetClass  must not be null";
     private static final String VALIDATOR_MUST_NOT_BE_NULL = "validator must not be null";
     private static final String COMPONENT_MUST_NOT_BE_NULL = "component must not be null";
-    private static final String COMPONENT_TYPE_NOT_BE_NULL = "component must not be null";
+    private static final String COMPONENT_TYPE_NOT_BE_NULL = "componentType must not be null";
     private static final String CONVERTER_MUST_NOT_BE_NULL = "converter  must not be null";
 
     @NonNull
@@ -137,10 +137,15 @@ public class ComponentConfigDecorator {
             "In order to work this method needs a converter annotated with 'jakarta.faces.convert.FacesConverter', converterClass:"
                 + converter.getName());
         final var facesConverter = converter.getAnnotation(FacesConverter.class);
-        if (!Object.class.equals(facesConverter.forClass())) {
+        final var hasForClass = !Object.class.equals(facesConverter.forClass());
+        final var hasValue = !facesConverter.value().isEmpty();
+        checkArgument(hasForClass || hasValue,
+            "The @FacesConverter annotation on '" + converter.getName()
+                + "' must define either 'value' or a specific 'forClass' in order to be registered");
+        if (hasForClass) {
             registerConverter(converter, facesConverter.forClass());
         }
-        if (!facesConverter.value().isEmpty()) {
+        if (hasValue) {
             registerConverter(converter, facesConverter.value());
         }
         return this;

--- a/src/main/java/de/cuioss/test/jsf/config/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/config/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides the configuration infrastructure for the JSF test-framework, such as
+ * the {@link de.cuioss.test.jsf.config.JsfTestConfiguration} annotation and the
+ * (deprecated) configurator callback interfaces.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.config;

--- a/src/main/java/de/cuioss/test/jsf/config/renderer/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/config/renderer/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides annotations and support types for renderer-specific test
+ * configuration.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.config.renderer;

--- a/src/main/java/de/cuioss/test/jsf/converter/AbstractConverterTest.java
+++ b/src/main/java/de/cuioss/test/jsf/converter/AbstractConverterTest.java
@@ -39,8 +39,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * context
  * <h3>Setup</h3>
  * <p>
- * {@link #initConverter()}: Instantiates the concrete {@link Converter} using
- * reflection. After this the method calls {@link #configure(Object)} that can
+ * {@link #initConverter(ComponentConfigDecorator)}: Instantiates the concrete
+ * {@link Converter} using reflection. After this the method calls
+ * {@link #configure(Object)} that can
  * be used for further configuration of the {@link Converter}
  * </p>
  * <p>

--- a/src/main/java/de/cuioss/test/jsf/converter/TestItems.java
+++ b/src/main/java/de/cuioss/test/jsf/converter/TestItems.java
@@ -110,7 +110,8 @@ public class TestItems<T> {
      * {@link Converter#getAsString(jakarta.faces.context.FacesContext, jakarta.faces.component.UIComponent, Object)}
      * Test item should pass without {@link ConverterException}
      *
-     * @param value valid value which should cause a {@link ConverterException}
+     * @param value valid value which should be converted without causing a
+     *              {@link ConverterException}
      * @return TestItems reference to this object
      */
     public TestItems<T> addValidObject(final T value) {
@@ -123,8 +124,8 @@ public class TestItems<T> {
      * Test item should pass without {@link ConverterException} and the result
      * should be the same as the given converterResult
      *
-     * @param value           valid value which should cause a
-     *                        {@link ConverterException}
+     * @param value           valid value which should be converted without
+     *                        causing a {@link ConverterException}
      * @param converterResult the String to be returned by
      *                        {@link Converter#getAsString(jakarta.faces.context.FacesContext, jakarta.faces.component.UIComponent, Object)}
      * @return TestItems reference to this object
@@ -246,9 +247,11 @@ public class TestItems<T> {
      * {@link Converter#getAsObject(jakarta.faces.context.FacesContext, jakarta.faces.component.UIComponent, String)}
      *
      * @param valid           indicating whether it is a valid or invalid item
-     * @param value           T value to be validated
-     * @param converterResult the String to be returned by
-     *                        {@link Converter#getAsString(jakarta.faces.context.FacesContext, jakarta.faces.component.UIComponent, Object)}
+     * @param value           the object value of the test item (the expected
+     *                        result of the conversion)
+     * @param converterResult the String value of the test item (the input passed
+     *                        to
+     *                        {@link Converter#getAsObject(jakarta.faces.context.FacesContext, jakarta.faces.component.UIComponent, String)})
      * @param level           {@link Severity} represent message severity, usually
      *                        {@link FacesMessage#SEVERITY_ERROR}
      * @param message         which should be set within the

--- a/src/main/java/de/cuioss/test/jsf/generator/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/generator/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides test-data generators for JSF-related types used within the
+ * test-framework.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.generator;

--- a/src/main/java/de/cuioss/test/jsf/junit5/AbstractPropertyAwareFacesTest.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/AbstractPropertyAwareFacesTest.java
@@ -31,7 +31,6 @@ import lombok.Getter;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.util.List;
-import java.util.SortedSet;
 
 /**
  * Base class for JSF-tests that is capable of dealing
@@ -80,7 +79,7 @@ public abstract class AbstractPropertyAwareFacesTest<T>
      * Resolves the {@link PropertyMetadata} by using reflections and the
      * annotations {@link PropertyConfig} and / {@link PropertyConfigs} if provided
      *
-     * @return a {@link SortedSet} of {@link PropertyMetadata} defining the base
+     * @return a {@link List} of {@link PropertyMetadata} defining the base
      * line for the configured attributes
      */
     protected List<PropertyMetadata> resolvePropertyMetadata() {

--- a/src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironment.java
+++ b/src/main/java/de/cuioss/test/jsf/junit5/EnableJsfEnvironment.java
@@ -19,6 +19,7 @@ import de.cuioss.test.jsf.config.ApplicationConfigurator;
 import de.cuioss.test.jsf.config.ComponentConfigurator;
 import de.cuioss.test.jsf.config.JsfTestConfiguration;
 import de.cuioss.test.jsf.config.RequestConfigurator;
+import de.cuioss.test.jsf.config.decorator.ComponentConfigDecorator;
 import de.cuioss.test.jsf.util.JsfEnvironmentHolder;
 import de.cuioss.test.valueobjects.util.IdentityResourceBundle;
 import jakarta.faces.context.FacesContext;
@@ -47,6 +48,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * corresponding methods accordingly, <em>after</em> the configurator derived by
  * the annotations</li>
  * </ul>
+ * <p>
+ * <strong>Note:</strong> The configurator-interface scanning described above
+ * (implementing {@link ApplicationConfigurator}, {@link RequestConfigurator} or
+ * {@link ComponentConfigurator}) as well as the {@code JsfEnvironmentConsumer}
+ * interface are deprecated. Prefer parameter resolution: declare the JSF objects
+ * and configuration decorators you need directly as test-method parameters.
+ * </p>
  * <h3>Using</h3>
  * <p>
  * Simple Sample: Use a preconfigured JSF-context for the test providing
@@ -63,20 +71,24 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * <p>
  * Complex Sample: Use a preconfigured JSF-context with access to the context
- * information like {@link FacesContext}, {@link ComponentConfigurator}, ... as
- * defined within {@link JsfEnvironmentHolder} With this setup you can
- * programmatically access the element
+ * information like {@link FacesContext}, {@link ComponentConfigDecorator}, ... by
+ * declaring them as test-method parameters (parameter resolution). With this
+ * setup you can programmatically access and configure the JSF environment
+ * within each test.
  * </p>
  *
  * <pre>
  * <code>
  * &#64;EnableJsfEnvironment
  * &#64;JsfTestConfiguration(BasicApplicationConfiguration.class)
- * class JsfSetupExtensionTest implements JsfEnvironmentConsumer {
+ * class JsfSetupExtensionTest {
  *
- * &#64;Setter
- * &#64;Getter
- * private JsfEnvironmentHolder environmentHolder;</code>
+ * &#64;Test
+ * void shouldConfigureComponent(FacesContext facesContext, ComponentConfigDecorator componentConfig) {
+ * componentConfig.registerRenderer(MyRenderer.class);
+ * // Test code using facesContext
+ * }
+ * }</code>
  * </pre>
  *
  * <p>

--- a/src/main/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandler.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/CuiMockResourceHandler.java
@@ -79,7 +79,7 @@ public class CuiMockResourceHandler extends ResourceHandler {
 
     /**
      * @return the configured resources
-     * @deprecated misspelled; use {@link #getAvailableResources()} instead. Retained
+     * @deprecated misspelled; use {@code getAvailableResources()} instead. Retained
      * for binary compatibility and scheduled for removal in the next major.
      */
     @Deprecated
@@ -89,7 +89,7 @@ public class CuiMockResourceHandler extends ResourceHandler {
 
     /**
      * @param availableResources the resources to configure
-     * @deprecated misspelled; use {@link #setAvailableResources(Map)} instead. Retained
+     * @deprecated misspelled; use {@code setAvailableResources(Map)} instead. Retained
      * for binary compatibility and scheduled for removal in the next major.
      */
     @Deprecated

--- a/src/main/java/de/cuioss/test/jsf/mocks/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/mocks/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides extended JSF mock implementations completing the ones shipped with
+ * MyFaces-Test, e.g. mocks for view-, resource- and navigation-handlers.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.mocks;

--- a/src/main/java/de/cuioss/test/jsf/producer/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/producer/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides producers for test objects used within the JSF test-framework.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.producer;

--- a/src/main/java/de/cuioss/test/jsf/renderer/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/renderer/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides base-classes and utilities for testing JSF
+ * {@link jakarta.faces.render.Renderer}s, including HTML-tree assertion tooling.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.renderer;

--- a/src/main/java/de/cuioss/test/jsf/util/ConfigurableFacesTest.java
+++ b/src/main/java/de/cuioss/test/jsf/util/ConfigurableFacesTest.java
@@ -67,7 +67,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * message key is used to create a message but do not want to test the actual
  * ResourceBundle mechanism itself. It will always return the given key itself.
  * As default this mechanism is active, you can change this by overwriting
- * #isUseIdentityResouceBundle(). If it is active it is used as well for
+ * #isUseIdentityResourceBundle(). If it is active it is used as well for
  * resolving the MessageBundle
  * </p>
  *
@@ -85,7 +85,7 @@ public class ConfigurableFacesTest {
     private ComponentConfigDecorator componentConfigDecorator;
     @Getter(AccessLevel.PROTECTED)
     private ApplicationConfigDecorator applicationConfigDecorator;
-    @Getter
+    @Getter(AccessLevel.PROTECTED)
     private RequestConfigDecorator requestConfigDecorator;
     private ConfigurableApplication configurableApplication;
 

--- a/src/main/java/de/cuioss/test/jsf/util/JsfEnvironmentConsumer.java
+++ b/src/main/java/de/cuioss/test/jsf/util/JsfEnvironmentConsumer.java
@@ -67,7 +67,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * assertNotNull(environmentHolder);
  * assertNotNull(getApplication());
  * assertNotNull(getApplicationConfigDecorator());
- * assertNotNull(getBeanConfigDecorator());
  * assertNotNull(getComponentConfigDecorator());
  * assertNotNull(getExternalContext());
  * assertNotNull(getFacesContext());

--- a/src/main/java/de/cuioss/test/jsf/util/JsfEnvironmentHolder.java
+++ b/src/main/java/de/cuioss/test/jsf/util/JsfEnvironmentHolder.java
@@ -59,7 +59,7 @@ public class JsfEnvironmentHolder {
     }
 
     /**
-     * @return an {@link ApplicationConfigDecorator} for the contained
+     * @return an {@link RequestConfigDecorator} for the contained
      * {@link JsfRuntimeSetup}
      */
     public RequestConfigDecorator getRequestConfigDecorator() {

--- a/src/main/java/de/cuioss/test/jsf/util/package-info.java
+++ b/src/main/java/de/cuioss/test/jsf/util/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides general utilities for the JSF test-framework, such as the JSF runtime
+ * setup and the {@link de.cuioss.test.jsf.util.JsfEnvironmentHolder}.
+ *
+ * @author Oliver Wolff
+ */
+package de.cuioss.test.jsf.util;

--- a/src/main/java/de/cuioss/test/jsf/validator/TestItems.java
+++ b/src/main/java/de/cuioss/test/jsf/validator/TestItems.java
@@ -58,10 +58,11 @@ public class TestItems<T> {
     }
 
     /**
-     * Add to TestData Store a Test item which must fail with
+     * Add to TestData Store a Test item which must pass validation without a
      * {@link ValidatorException}
      *
-     * @param value T invalid value which should cause a {@link ValidatorException}
+     * @param value T valid value which must pass validation without causing a
+     *              {@link ValidatorException}
      * @return TestItems reference to this object
      */
     public TestItems<T> addValid(final T value) {

--- a/src/test/java/de/cuioss/test/jsf/config/decorator/ComponentConfigDecoratorTest.java
+++ b/src/test/java/de/cuioss/test/jsf/config/decorator/ComponentConfigDecoratorTest.java
@@ -24,7 +24,9 @@ import jakarta.faces.application.Application;
 import jakarta.faces.component.*;
 import jakarta.faces.component.html.HtmlForm;
 import jakarta.faces.component.html.HtmlInputText;
+import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
+import jakarta.faces.convert.FacesConverter;
 import jakarta.faces.convert.Converter;
 import jakarta.faces.render.Renderer;
 import jakarta.faces.validator.LengthValidator;
@@ -183,6 +185,13 @@ class ComponentConfigDecoratorTest {
     }
 
     @Test
+    @DisplayName("Should reject a converter whose @FacesConverter defines neither value nor forClass (DOC-12)")
+    void shouldRejectConverterWithoutIdOrType(ComponentConfigDecorator decorator) {
+        assertThrows(IllegalArgumentException.class, () -> decorator.registerConverter(BareConverter.class),
+            "A @FacesConverter with neither value nor forClass must be rejected instead of registering nothing");
+    }
+
+    @Test
     @DisplayName("Should register a converter from its annotated type")
     void shouldRegisterConverterWithAnnotatetdType(ComponentConfigDecorator decorator, Application application) {
         assertConverterForTypeIsNotRegistered(application, Serializable.class);
@@ -292,5 +301,19 @@ class ComponentConfigDecoratorTest {
             final String rendererType) {
         final Renderer renderer = facesContext.getRenderKit().getRenderer(family, rendererType);
         assertNull(renderer, "Renderer is registered " + rendererType + ", " + family);
+    }
+
+    /** A converter whose {@code @FacesConverter} defines neither a value nor a specific forClass. */
+    @FacesConverter
+    public static class BareConverter implements Converter<Object> {
+        @Override
+        public Object getAsObject(FacesContext context, UIComponent component, String value) {
+            return value;
+        }
+
+        @Override
+        public String getAsString(FacesContext context, UIComponent component, Object value) {
+            return String.valueOf(value);
+        }
     }
 }


### PR DESCRIPTION
## Cluster 7 — Documentation & Javadoc (PR-7)

Last implementation cluster, so the docs describe the final post-fix state. Per `doc/review-26-07-04.md`.

### Findings addressed
| ID | Fix |
|----|-----|
| DOC-1 [C] | `doc/usage.adoc` renderer example rewritten against the real API (3-arg `assertRenderResult` with a String, `ComponentConfigDecorator` parameter) |
| DOC-2 [C] | `CLAUDE.md` — removed `HtmlTreeBuilder` from the architecture list and rewrote the renderer example |
| DOC-3 [C] / BUILD-10 | `-Prewrite` → `-Ppre-commit`; version `4.4-SNAPSHOT`; parent `1.4.5` |
| DOC-4 [M] | Point at `doc/migration/4.1.adoc` and `4.3.adoc` |
| DOC-5 [M] | `javax.faces.*` → `jakarta.faces.*` in examples |
| DOC-6 [m] | "HTML-tree assertion tooling" |
| DOC-7 [m] | "Jakarta Faces 4.1 (Jakarta EE 11)" |
| DOC-8 [m] | `JsfEnabledTestEnvironment` documented as removed in 4.x |
| DOC-9 [m] | Correct `useIdentityResourceBundle` spelling |
| DOC-10 [m] | `NavigationAsserts` under `junit5`; `release/v2` branch |
| DOC-11 [m] | `EnableJsfEnvironment` Javadoc shows parameter resolution; legacy paths marked deprecated |
| DOC-12 [m] | Fix contradictory/copy-paste Javadoc across `TestItems` (converter & validator), `JsfEnvironmentHolder`, `JsfEnvironmentConsumer`, `ApplicationConfigDecorator` (+`setProjectStage` message), `ComponentConfigDecorator` (`componentType` message + a guard rejecting a `@FacesConverter` with neither value nor forClass), `ValueExpressionPropertyContract`, `AbstractPropertyAwareFacesTest` |
| DOC-13 [m] | `package-info.java` for the nine public packages |
| DOC-14 [m] | Align `ConfigurableFacesTest` getter visibility (protected) |
| DOC-15 [m] | `./mvnw -Pjavadoc clean install` builds cleanly — **0** reference-not-found warnings |

### Verification
`./mvnw clean install` green (290 tests, 1 intentionally disabled) and the javadoc profile builds with **no** warnings. Adds a regression test for the `registerConverter` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y95DNbN4fZHSdaR4wAckzN)_