### PR TITLE
chore(config): migrate retired automated-review step key to plan-marshall:automatic-review

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -67,7 +67,7 @@
         "default:push": {},
         "default:create-pr": {},
         "default:ci-verify": {},
-        "default:automated-review": {
+        "plan-marshall:automatic-review": {
           "review_bot_buffer_seconds": 180,
           "re_review_on_loopback": false,
           "re_review_on_branch_cleanup": true,


### PR DESCRIPTION
One-line marshal.json migration: upstream renamed the automatic-review finalize step, and the retired `default:automated-review` key makes the manifest composer emit an unloadable step that hard-blocks finalize (observed live on nifi-extensions PR #432, captured there as lesson 2026-07-12-15-001; showed as a duplicate review step on TokenSheriff PR #560). Canonical form verified against the plan-marshall meta repo and nifi-extensions: `plan-marshall:automatic-review`. Knob values unchanged.